### PR TITLE
Fix the /67 route and camera startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 ## Production notes
 
 - The retired OJ is controlled by `OJ_ENABLED` and defaults to `False`. Its code and database tables remain intact.
+- The 67 Counter uses the published MediaPipe Tasks Vision `1.0.1` browser bundle. It asks for camera permission before loading the pose runtime, and falls back from jsDelivr to unpkg if one CDN is filtered.
 - Hall of Fame videos require `ffprobe` (provided by the `ffmpeg` system package) for server-side duration/stream validation.
 - Recordings are written to `PRIVATE_MEDIA_ROOT` (default: `private_media/`). Do **not** expose that directory as a public nginx/static alias; videos are served through a permission-checking Django route.
 - Enforce `client_max_body_size 26M;` (or the equivalent at the reverse proxy) in addition to the application-level 25 MiB limit.

--- a/brainrot/admin.py
+++ b/brainrot/admin.py
@@ -18,7 +18,7 @@ class HallOfFameEntryAdmin(admin.ModelAdmin):
     def review_video(self, obj):
         if not obj.pk:
             return 'Save first'
-        return format_html('<a href="{}" target="_blank">Open private recording</a>', f'/brainrot/67/hall-of-fame/{obj.pk}/video/')
+        return format_html('<a href="{}" target="_blank">Open private recording</a>', f'/67/hall-of-fame/{obj.pk}/video/')
 
     @admin.action(description='Approve selected entries')
     def approve_entries(self, request, queryset):
@@ -27,4 +27,3 @@ class HallOfFameEntryAdmin(admin.ModelAdmin):
     @admin.action(description='Reject selected entries')
     def reject_entries(self, request, queryset):
         queryset.update(state=HallOfFameEntry.State.REJECTED, reviewed_at=timezone.now())
-

--- a/brainrot/middleware.py
+++ b/brainrot/middleware.py
@@ -9,7 +9,7 @@ class HallOfFameUploadLimitMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        if request.method == 'POST' and request.path.rstrip('/') == '/brainrot/67/submit':
+        if request.method == 'POST' and request.path.rstrip('/') == '/67/submit':
             try:
                 content_length = int(request.META.get('CONTENT_LENGTH') or 0)
             except (TypeError, ValueError):
@@ -18,4 +18,3 @@ class HallOfFameUploadLimitMiddleware:
             if content_length > allowance:
                 return JsonResponse({'error': 'Recording is too large.'}, status=413)
         return self.get_response(request)
-

--- a/brainrot/static/brainrot/counter.js
+++ b/brainrot/static/brainrot/counter.js
@@ -1,8 +1,3 @@
-import {
-  FilesetResolver,
-  PoseLandmarker,
-} from 'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.26/+esm';
-
 const app = document.getElementById('counter-app');
 if (app) {
   const video = document.getElementById('camera');
@@ -46,6 +41,29 @@ if (app) {
   let recordingChunks = [];
   let recordingBlob = null;
   let recordingUrl = null;
+
+  async function loadMediaPipe() {
+    const sources = [
+      {
+        module: 'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@1.0.1/vision_bundle.mjs',
+        wasm: 'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@1.0.1/wasm',
+      },
+      {
+        module: 'https://unpkg.com/@mediapipe/tasks-vision@1.0.1/vision_bundle.mjs',
+        wasm: 'https://unpkg.com/@mediapipe/tasks-vision@1.0.1/wasm',
+      },
+    ];
+    let lastError = null;
+    for (const source of sources) {
+      try {
+        const library = await import(source.module);
+        return { ...library, wasmRoot: source.wasm };
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    throw new Error(`Could not load the pose runtime from either CDN: ${lastError?.message || 'network blocked'}`);
+  }
 
   function setStatus(message, state = '') {
     status.className = `detector-status ${state}`;
@@ -184,11 +202,10 @@ if (app) {
       video.srcObject = stream;
       await video.play();
       placeholder.hidden = true;
-      setStatus('Loading local pose model…', 'busy');
+      setStatus('Loading the pose model into this browser…', 'busy');
 
-      const vision = await FilesetResolver.forVisionTasks(
-        'https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@0.10.26/wasm',
-      );
+      const { FilesetResolver, PoseLandmarker, wasmRoot } = await loadMediaPipe();
+      const vision = await FilesetResolver.forVisionTasks(wasmRoot);
       const options = {
         baseOptions: {
           modelAssetPath: 'https://storage.googleapis.com/mediapipe-models/pose_landmarker/pose_landmarker_lite/float16/1/pose_landmarker_lite.task',
@@ -210,8 +227,17 @@ if (app) {
       detectorLoop = requestAnimationFrame(detectFrame);
     } catch (error) {
       enableButton.disabled = false;
-      setStatus('Camera or detector unavailable');
-      showError('Could not start the camera. Use HTTPS, allow camera access, and try a current browser.');
+      if (stream) {
+        stream.getTracks().forEach((track) => track.stop());
+        stream = null;
+        video.srcObject = null;
+        placeholder.hidden = false;
+        setStatus('Camera permission worked, but the pose runtime did not load');
+        showError(error.message || 'The pose runtime was blocked by this network.');
+      } else {
+        setStatus('Camera unavailable');
+        showError('Could not start the camera. Use HTTPS, allow camera access, and try a current browser.');
+      }
     }
   }
 

--- a/brainrot/tests.py
+++ b/brainrot/tests.py
@@ -11,7 +11,7 @@ from .validators import ValidatedVideo
 
 class BrainrotPageTests(TestCase):
     def test_public_pages_load(self):
-        for path in ('/brainrot/', '/brainrot/67/', '/brainrot/67/hall-of-fame/', '/brainrot/typing/'):
+        for path in ('/67/', '/67/games/', '/67/hall-of-fame/', '/67/typing/'):
             with self.subTest(path=path):
                 self.assertEqual(self.client.get(path).status_code, 200)
 
@@ -29,7 +29,7 @@ class HallOfFameSubmissionTests(TestCase):
         self.private_directory.cleanup()
 
     def test_anonymous_upload_is_rejected(self):
-        response = self.client.post('/brainrot/67/submit/', {'score': 67})
+        response = self.client.post('/67/submit/', {'score': 67})
         self.assertEqual(response.status_code, 302)
         self.assertEqual(HallOfFameEntry.objects.count(), 0)
 
@@ -38,14 +38,14 @@ class HallOfFameSubmissionTests(TestCase):
         validate.return_value = ValidatedVideo('video/webm', 'webm', 23.0)
         self.client.login(username='scientist', password='test-password-67')
         video = SimpleUploadedFile('run.webm', b'video evidence', content_type='video/webm')
-        response = self.client.post('/brainrot/67/submit/', {'score': 67, 'video': video})
+        response = self.client.post('/67/submit/', {'score': 67, 'video': video})
         self.assertEqual(response.status_code, 201)
         entry = HallOfFameEntry.objects.get()
         self.assertEqual(entry.state, HallOfFameEntry.State.PENDING)
-        self.assertFalse(self.client.get('/brainrot/67/hall-of-fame/').context['entries'])
+        self.assertFalse(self.client.get('/67/hall-of-fame/').context['entries'])
 
         second = SimpleUploadedFile('run.webm', b'more evidence', content_type='video/webm')
-        response = self.client.post('/brainrot/67/submit/', {'score': 68, 'video': second})
+        response = self.client.post('/67/submit/', {'score': 68, 'video': second})
         self.assertEqual(response.status_code, 429)
         self.assertEqual(HallOfFameEntry.objects.count(), 1)
 
@@ -57,7 +57,7 @@ class HallOfFameSubmissionTests(TestCase):
             mime_type='video/webm',
             duration_seconds=20,
         )
-        path = f'/brainrot/67/hall-of-fame/{entry.id}/video/'
+        path = f'/67/hall-of-fame/{entry.id}/video/'
         self.assertEqual(self.client.get(path).status_code, 404)
 
         self.client.login(username='scientist', password='test-password-67')

--- a/brainrot/urls.py
+++ b/brainrot/urls.py
@@ -5,10 +5,10 @@ from . import views
 app_name = 'brainrot'
 
 urlpatterns = [
-    path('', views.index, name='index'),
-    path('67/', views.counter, name='counter'),
-    path('67/submit/', views.submit_hall_of_fame, name='submit_hall_of_fame'),
-    path('67/hall-of-fame/', views.hall_of_fame, name='hall_of_fame'),
-    path('67/hall-of-fame/<int:entry_id>/video/', views.hall_of_fame_video, name='hall_of_fame_video'),
+    path('', views.counter, name='counter'),
+    path('games/', views.index, name='index'),
+    path('submit/', views.submit_hall_of_fame, name='submit_hall_of_fame'),
+    path('hall-of-fame/', views.hall_of_fame, name='hall_of_fame'),
+    path('hall-of-fame/<int:entry_id>/video/', views.hall_of_fame_video, name='hall_of_fame_video'),
     path('typing/', views.typing_test, name='typing_test'),
 ]

--- a/brainrot/views.py
+++ b/brainrot/views.py
@@ -7,6 +7,7 @@ from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.http import FileResponse, JsonResponse
 from django.shortcuts import get_object_or_404, render
+from django.urls import reverse
 from django.utils import timezone
 from django.views.decorators.csrf import ensure_csrf_cookie
 from django.views.decorators.http import require_POST
@@ -122,7 +123,7 @@ def submit_hall_of_fame(request):
     return JsonResponse({
         'ok': True,
         'message': 'Submitted for human review. Peer review has never been this important.',
-        'hall_of_fame_url': '/brainrot/67/hall-of-fame/',
+        'hall_of_fame_url': reverse('brainrot:hall_of_fame'),
     }, status=201)
 
 

--- a/homepage/templates/homepage/index.html
+++ b/homepage/templates/homepage/index.html
@@ -115,7 +115,7 @@
                 <a href="/blog">{% trans "blog" %}</a>,
                 <a href="/orac-leaderboards">ORAC Leaderboards++</a>,
                 {% trans "or" %}
-                <a href="{% url 'brainrot:index' %}">61/67 Research Division</a>.
+                <a href="{% url 'brainrot:counter' %}">61/67 Research Division</a>.
             </p>
         </div>
     </div>
@@ -133,7 +133,7 @@
         <a href="/oracdata" class="nav-card btn-analytics">
             📊 {% trans "ORAC2 Analytics" %}
         </a>
-        <a href="{% url 'brainrot:index' %}" class="nav-card btn-brainrot">
+        <a href="{% url 'brainrot:counter' %}" class="nav-card btn-brainrot">
             🧪 61/67 Research Division
         </a>
     </div>

--- a/myblog/urls.py
+++ b/myblog/urls.py
@@ -29,7 +29,7 @@ urlpatterns = [
     path('i18n/',include("django.conf.urls.i18n")),
     path('orac-leaderboards/', include('orac_tracker.urls')),
     path('oj/', include('oj.urls')),
-    path('brainrot/', include('brainrot.urls')),
+    path('67/', include('brainrot.urls')),
     path('', include('oracdata.urls')),
     path("vip/", include("prank.urls")),
 ]+static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)

--- a/oj/templates/oj/retired.html
+++ b/oj/templates/oj/retired.html
@@ -7,7 +7,7 @@
   <section class="retired-card">
     <span class="retired-badge">HTTP 410 · ARCHIVED EXPERIMENT</span>
     <h1>Speed Online Judge</h1>
-    <p class="retired-punchline">被 y8 kid 制裁了 🤣</p>
+    <p class="retired-punchline">The y8 kids won 🤣</p>
     <p>This service has been retired.</p>
     <a href="{% url 'home' %}" class="btn btn-dark">Return to civilisation</a>
   </section>

--- a/templates/base.html
+++ b/templates/base.html
@@ -64,7 +64,7 @@
               <a class="nav-link" href="/orac-leaderboards"><i class="fa-solid fa-ranking-star"></i> ORAC LB</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="{% url 'brainrot:index' %}"><i class="fa-solid fa-flask"></i> 61/67 Lab</a>
+              <a class="nav-link" href="{% url 'brainrot:counter' %}"><i class="fa-solid fa-flask"></i> 61/67 Lab</a>
             </li>
             <li class="nav-item">
               <a class="nav-link" href="/oj"><i class="fa-solid fa-box-archive"></i> {% trans 'OJ' %}</a>


### PR DESCRIPTION
## Fixes

- Make the main counter entry `/67/` and move its related routes below the same prefix.
- Replace the nonexistent `@mediapipe/tasks-vision@0.10.26/+esm` import with the published `1.0.1/vision_bundle.mjs` entry.
- Register the camera button before loading MediaPipe, request camera permission first, and fall back from jsDelivr to unpkg.
- Change the OJ retirement punchline to English.

## Root cause

`0.10.26` is not a published version of the `@mediapipe/tasks-vision` npm package. jsDelivr returned a plain-text error response, which Firefox correctly rejected as a JavaScript module. Since that failure happened at the top-level import, none of the button handlers—including camera permission—were registered.

## Checks

- `python manage.py check`
- `python manage.py makemigrations --check --dry-run`
- `python manage.py test oj brainrot --verbosity 2` — 6 tests passed
- `node --check brainrot/static/brainrot/counter.js`
- `git diff --check`
- confirmed the 1.0.1 bundle returns `application/javascript` and its WASM returns `application/wasm`
