### PR TITLE
Improve 61/67 sharing, starts, and Hall publishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 - The retired OJ is controlled by `OJ_ENABLED` and defaults to `False`. Its code and database tables remain intact.
 - The 67 Counter uses the published MediaPipe Tasks Vision `1.0.1` browser bundle. It asks for camera permission before loading the pose runtime, and falls back from jsDelivr to unpkg if one CDN is filtered.
+- Counter CSS and JavaScript URLs are cache-busted in the template. If a browser still requests the nonexistent `@mediapipe/tasks-vision@0.10.26/+esm`, production is serving a stale collected static file: run `collectstatic`, reload the static server, and purge any reverse-proxy/CDN cache.
 - Hall of Fame videos require `ffprobe` (provided by the `ffmpeg` system package) for server-side duration/stream validation.
 - Recordings are written to `PRIVATE_MEDIA_ROOT` (default: `private_media/`). Do **not** expose that directory as a public nginx/static alias; videos are served through a permission-checking Django route.
 - Enforce `client_max_body_size 26M;` (or the equivalent at the reverse proxy) in addition to the application-level 25 MiB limit.

--- a/brainrot/static/brainrot/brainrot.css
+++ b/brainrot/static/brainrot/brainrot.css
@@ -158,6 +158,22 @@
 .result-card h2 { margin-top: .4rem; font-weight: 900; }
 .recording-review video { width: 100%; max-height: 310px; border-radius: 12px; background: #111827; }
 .recording-review p { color: var(--br-muted); font-size: .85rem; }
+.counter-share { grid-column: 1 / -1; padding-top: 1.25rem; border-top: 1px solid var(--br-line); }
+.counter-share h3 { margin: 0 0 .75rem; font-size: 1rem; font-weight: 850; text-align: center; }
+.counter-share textarea {
+  display: block;
+  width: 100%;
+  min-height: 9.5rem;
+  padding: .9rem 1rem;
+  resize: vertical;
+  border: 1px solid var(--br-line);
+  border-radius: 11px;
+  background: #f8fafc;
+  color: var(--br-ink);
+  font: .92rem/1.55 ui-monospace, SFMono-Regular, Consolas, monospace;
+}
+.counter-share .br-secondary { width: auto; min-width: 180px; margin: .75rem auto 0; display: block; }
+.counter-share .subtle { min-height: 1.2rem; margin: .45rem 0 0; text-align: center; }
 .subtle { color: var(--br-muted); font-size: .82rem; }
 
 .typing-heading { margin: 6rem 0 1.5rem; }

--- a/brainrot/static/brainrot/counter.js
+++ b/brainrot/static/brainrot/counter.js
@@ -16,6 +16,9 @@ if (app) {
   const resultCard = document.getElementById('counter-result');
   const resultScore = document.getElementById('result-score');
   const resultCopy = document.getElementById('result-copy');
+  const shareText = document.getElementById('counter-share-text');
+  const copyShareButton = document.getElementById('copy-counter-share');
+  const copyShareStatus = document.getElementById('copy-counter-status');
   const recordingReview = document.getElementById('recording-review');
   const recordingPreview = document.getElementById('recording-preview');
   const submitButton = document.getElementById('submit-hof');
@@ -81,6 +84,37 @@ if (app) {
   function csrfToken() {
     const match = document.cookie.match(/(?:^|; )csrftoken=([^;]+)/);
     return match ? decodeURIComponent(match[1]) : '';
+  }
+
+  function shareableResult() {
+    const headline = score === 67
+      ? 'I scored exactly 67 in the 67 Counter. Peer review is complete. 🧪'
+      : `I scored ${score} in the 67 Counter. The data is unfortunately real. 🧪`;
+    const blocks = score > 0
+      ? `${'🟩'.repeat(Math.min(score, 67))}${score > 67 ? ` +${score - 67}` : ''}`
+      : '⬜';
+    const url = new URL('/67/', window.location.origin).href;
+    return `${headline}\n20 seconds of arm-based research\n${blocks}\nSIX SEVEN\nCan you do better?\n${url}`;
+  }
+
+  async function copyShareResult() {
+    if (!shareText?.value) return;
+    try {
+      if (navigator.clipboard?.writeText && window.isSecureContext) {
+        await navigator.clipboard.writeText(shareText.value);
+      } else {
+        shareText.select();
+        shareText.setSelectionRange(0, shareText.value.length);
+        if (!document.execCommand('copy')) throw new Error('Copy command was rejected.');
+      }
+      copyShareButton.textContent = 'Copied! 🎉';
+      copyShareStatus.textContent = 'Result copied. Scientific distribution may begin.';
+    } catch (error) {
+      copyShareStatus.textContent = 'Automatic copy failed. Select the text and copy it manually.';
+    }
+    window.setTimeout(() => {
+      copyShareButton.textContent = 'Copy to clipboard';
+    }, 1500);
   }
 
   function preferredRecordingType() {
@@ -334,6 +368,8 @@ if (app) {
       : score > 67
         ? 'The 67 barrier has been disturbed.'
         : 'The Institute recommends more arm-based research.';
+    shareText.value = shareableResult();
+    copyShareStatus.textContent = '';
     resultCard.hidden = false;
     recordingReview.hidden = currentMode !== 'hof';
     if (blob) {
@@ -361,6 +397,8 @@ if (app) {
     scoreEl.textContent = '0';
     timeEl.textContent = GAME_SECONDS.toFixed(1);
     resultCard.hidden = true;
+    shareText.value = '';
+    copyShareStatus.textContent = '';
     resetButton.hidden = true;
     modeInputs.forEach((input) => { input.disabled = false; });
     startButton.disabled = !poseReady;
@@ -417,6 +455,7 @@ if (app) {
   resetButton.addEventListener('click', resetRun);
   submitButton?.addEventListener('click', submitRecording);
   discardButton?.addEventListener('click', discardRecording);
+  copyShareButton?.addEventListener('click', copyShareResult);
   window.addEventListener('beforeunload', () => {
     if (recordingUrl) URL.revokeObjectURL(recordingUrl);
     stream?.getTracks().forEach((track) => track.stop());

--- a/brainrot/templates/brainrot/counter.html
+++ b/brainrot/templates/brainrot/counter.html
@@ -4,7 +4,7 @@
 {% block title %}67 Counter{% endblock %}
 
 {% block content %}
-<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}">
+<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260814.2">
 {% if turnstile_enabled %}<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>{% endif %}
 
 <main class="br-page counter-page" id="counter-app"
@@ -92,8 +92,15 @@
       {% endif %}
       <p id="upload-status" role="status"></p>
     </div>
+    <div class="counter-share" id="counter-share">
+      <h3>🎉 Share your result!</h3>
+      <textarea id="counter-share-text" rows="6" readonly aria-label="Shareable 67 Counter result"></textarea>
+      <button class="br-secondary" id="copy-counter-share" type="button">Copy to clipboard</button>
+      <p class="subtle" id="copy-counter-status" role="status" aria-live="polite"></p>
+    </div>
   </section>
 </main>
 
-<script type="module" src="{% static 'brainrot/counter.js' %}"></script>
+{# Keep this version in step with counter.js so browsers cannot retain a broken runtime URL. #}
+<script type="module" src="{% static 'brainrot/counter.js' %}?v=20260814.2"></script>
 {% endblock %}

--- a/brainrot/tests.py
+++ b/brainrot/tests.py
@@ -1,7 +1,9 @@
 import tempfile
+from pathlib import Path
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
+from django.contrib.staticfiles import finders
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase, override_settings
 
@@ -14,6 +16,19 @@ class BrainrotPageTests(TestCase):
         for path in ('/67/', '/67/games/', '/67/hall-of-fame/', '/67/typing/'):
             with self.subTest(path=path):
                 self.assertEqual(self.client.get(path).status_code, 200)
+
+    def test_counter_uses_cache_busted_runtime_and_has_share_box(self):
+        response = self.client.get('/67/')
+        self.assertContains(response, 'brainrot.css?v=20260814.2')
+        self.assertContains(response, 'counter.js?v=20260814.2')
+        self.assertContains(response, 'id="counter-share-text"')
+        self.assertContains(response, 'id="copy-counter-share"')
+
+        script_path = finders.find('brainrot/counter.js')
+        self.assertIsNotNone(script_path)
+        script = Path(script_path).read_text(encoding='utf-8')
+        self.assertIn('@mediapipe/tasks-vision@1.0.1/vision_bundle.mjs', script)
+        self.assertNotIn('@mediapipe/tasks-vision@0.10.26', script)
 
 
 @override_settings(TURNSTILE_ENABLED=False, HOF_SUBMISSIONS_PER_HOUR=1)


### PR DESCRIPTION
## Summary

- cache-bust the 67 Counter and typing assets so browsers stop retaining old runtime code
- keep the camera-first startup and valid MediaPipe Tasks Vision `1.0.1` CDN fallback
- change Counter startup to an `I'm ready` arming flow: a stable detected pose automatically starts the 3-second countdown
- start Hall of Fame recording only when the pose locks, avoiding long setup footage
- add OJ-style share boxes to both games; the typing share intentionally contains no URL
- publish validated Hall of Fame submissions immediately while retaining authentication, Turnstile, rate, size, MIME, and duration protection
- keep admin deletion wired to removal of the stored video file
- add regression coverage for asset versions, share controls, and immediate Hall publication

## Deployment note

If a browser requests the nonexistent `@mediapipe/tasks-vision@0.10.26/+esm`, production is serving an old collected static file. After merging, run:

```sh
python manage.py collectstatic --noinput
```

Then reload the static server and purge any reverse-proxy/CDN cache if present.

## Verification

- `node --check brainrot/static/brainrot/counter.js`
- `node --check brainrot/static/brainrot/typing.js`
- `python manage.py check`
- `python manage.py makemigrations --check --dry-run`
- `python manage.py test brainrot oj` (8 tests passed)
