### PR TITLE
Add typing sharing and automatic 67 starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 - Recordings are written to `PRIVATE_MEDIA_ROOT` (default: `private_media/`). Do **not** expose that directory as a public nginx/static alias; videos are served through a permission-checking Django route.
 - Enforce `client_max_body_size 26M;` (or the equivalent at the reverse proxy) in addition to the application-level 25 MiB limit.
 - Hall of Fame uploads require a logged-in account and are limited per account. For production, configure `TURNSTILE_SITE_KEY` and `TURNSTILE_SECRET_KEY` to add Cloudflare Turnstile with mandatory server-side verification.
-- Deleting a Hall of Fame entry in Django admin also deletes its private recording. Periodically remove rejected/stale pending entries to reclaim disk space.
+- Valid Hall of Fame uploads are published immediately. Delete obvious fake or abusive entries in Django admin; deleting an entry also deletes its private recording.
 
 Deploy database/static changes with:
 

--- a/brainrot/static/brainrot/brainrot.css
+++ b/brainrot/static/brainrot/brainrot.css
@@ -174,6 +174,7 @@
 }
 .counter-share .br-secondary { width: auto; min-width: 180px; margin: .75rem auto 0; display: block; }
 .counter-share .subtle { min-height: 1.2rem; margin: .45rem 0 0; text-align: center; }
+.typing-share { margin-top: 1.25rem; }
 .subtle { color: var(--br-muted); font-size: .82rem; }
 
 .typing-heading { margin: 6rem 0 1.5rem; }

--- a/brainrot/static/brainrot/counter.js
+++ b/brainrot/static/brainrot/counter.js
@@ -35,6 +35,8 @@ if (app) {
   let poseReady = false;
   let readyFrames = 0;
   let running = false;
+  let armed = false;
+  let countdownActive = false;
   let currentMode = 'casual';
   let endTime = 0;
   let score = 0;
@@ -205,15 +207,18 @@ if (app) {
         else readyFrames = Math.max(0, readyFrames - 2);
         poseReady = readyFrames >= 5;
 
-        if (!running) {
-          if (poseReady) {
-            setStatus('Pose detected — alternate both hands vertically', 'ready');
-            startButton.disabled = false;
-            startButton.textContent = 'Start 20 second run';
+        if (!running && !countdownActive) {
+          if (armed) {
+            if (poseReady) {
+              beginRun();
+            } else {
+              setStatus('Armed — step back until shoulders, elbows and wrists are visible', 'busy');
+              startButton.textContent = 'Waiting for your pose…';
+            }
+          } else if (poseReady) {
+            setStatus('Pose detected — click I\'m ready, then take your position', 'ready');
           } else {
-            setStatus('Detector ready — place shoulders, elbows and wrists in frame', 'busy');
-            startButton.disabled = true;
-            startButton.textContent = 'Waiting for a visible pose…';
+            setStatus('Detector ready — click I\'m ready, then step into frame', 'ready');
           }
         }
         observeGesture(landmarks, performance.now());
@@ -258,6 +263,8 @@ if (app) {
         landmarker = await PoseLandmarker.createFromOptions(vision, options);
       }
       enableButton.hidden = true;
+      startButton.disabled = false;
+      startButton.textContent = "I'm ready";
       detectorLoop = requestAnimationFrame(detectFrame);
     } catch (error) {
       enableButton.disabled = false;
@@ -316,27 +323,40 @@ if (app) {
     gameLoop = requestAnimationFrame(updateGameClock);
   }
 
-  async function beginRun() {
-    if (!poseReady || running) return;
+  function armRun() {
+    if (!landmarker || running || countdownActive || armed) return;
     currentMode = document.querySelector('input[name="mode"]:checked').value;
     showError('');
     resultCard.hidden = true;
     resetButton.hidden = true;
     startButton.disabled = true;
+    startButton.textContent = 'Waiting for your pose…';
     modeInputs.forEach((input) => { input.disabled = true; });
     score = 0;
     lastZone = 0;
     lastCountAt = 0;
     scoreEl.textContent = '0';
     timeEl.textContent = GAME_SECONDS.toFixed(1);
+    armed = true;
+    setStatus('Armed — step back until shoulders, elbows and wrists are visible', 'busy');
+    if (poseReady) beginRun();
+  }
+
+  async function beginRun() {
+    if (!armed || !poseReady || running || countdownActive) return;
+    armed = false;
+    countdownActive = true;
+    setStatus('Pose locked — countdown commencing', 'ready');
 
     if (currentMode === 'hof') {
       try {
         startRecording();
       } catch (error) {
         showError(error.message);
+        countdownActive = false;
         modeInputs.forEach((input) => { input.disabled = false; });
         startButton.disabled = false;
+        startButton.textContent = "I'm ready";
         return;
       }
     }
@@ -348,6 +368,7 @@ if (app) {
     countdownEl.textContent = 'GO';
     await delay(350);
     countdownEl.textContent = '';
+    countdownActive = false;
     running = true;
     endTime = performance.now() + GAME_SECONDS * 1000;
     setStatus('Experiment in progress', 'ready');
@@ -393,6 +414,8 @@ if (app) {
 
   function resetRun() {
     discardRecording();
+    armed = false;
+    countdownActive = false;
     score = 0;
     scoreEl.textContent = '0';
     timeEl.textContent = GAME_SECONDS.toFixed(1);
@@ -401,8 +424,8 @@ if (app) {
     copyShareStatus.textContent = '';
     resetButton.hidden = true;
     modeInputs.forEach((input) => { input.disabled = false; });
-    startButton.disabled = !poseReady;
-    startButton.textContent = poseReady ? 'Start 20 second run' : 'Waiting for a visible pose…';
+    startButton.disabled = !landmarker;
+    startButton.textContent = landmarker ? "I'm ready" : 'Detector is still loading…';
     showError('');
   }
 
@@ -451,7 +474,7 @@ if (app) {
     });
   });
   enableButton.addEventListener('click', initialiseDetector);
-  startButton.addEventListener('click', beginRun);
+  startButton.addEventListener('click', armRun);
   resetButton.addEventListener('click', resetRun);
   submitButton?.addEventListener('click', submitRecording);
   discardButton?.addEventListener('click', discardRecording);

--- a/brainrot/static/brainrot/typing.js
+++ b/brainrot/static/brainrot/typing.js
@@ -8,6 +8,9 @@
   const wpmEl = document.getElementById('typing-wpm');
   const accuracyEl = document.getElementById('typing-accuracy');
   const result = document.getElementById('typing-result');
+  const shareText = document.getElementById('typing-share-text');
+  const copyShareButton = document.getElementById('copy-typing-share');
+  const copyShareStatus = document.getElementById('copy-typing-status');
   const durationButtons = [...document.querySelectorAll('[data-duration]')];
 
   let duration = 30;
@@ -82,6 +85,31 @@
     }
   }
 
+  function shareableResult(current, completedGroups, count61, count67) {
+    const verdict = current.wpm === 67
+      ? 'The prophecy has cleared peer review.'
+      : 'Statistically significant brainrot has occurred.';
+    return `I typed 61 / 67 at ${current.wpm} WPM with ${current.accuracy}% accuracy. 🧪\n${completedGroups} groups survived the keyboard\n61 × ${count61} | 67 × ${count67}\n${verdict}\nSIX SEVEN`;
+  }
+
+  async function copyShareResult() {
+    if (!shareText.value) return;
+    try {
+      if (navigator.clipboard?.writeText && window.isSecureContext) {
+        await navigator.clipboard.writeText(shareText.value);
+      } else {
+        shareText.select();
+        shareText.setSelectionRange(0, shareText.value.length);
+        if (!document.execCommand('copy')) throw new Error('Copy command was rejected.');
+      }
+      copyShareButton.textContent = 'Copied! 🎉';
+      copyShareStatus.textContent = 'Result copied. No leaderboard was harmed.';
+    } catch (error) {
+      copyShareStatus.textContent = 'Automatic copy failed. Select the text and copy it manually.';
+    }
+    window.setTimeout(() => { copyShareButton.textContent = 'Copy to clipboard'; }, 1500);
+  }
+
   function finish() {
     if (finished) return;
     finished = true;
@@ -102,6 +130,8 @@
     document.getElementById('result-groups').textContent = completedGroups;
     document.getElementById('result-61').textContent = count61;
     document.getElementById('result-67').textContent = count67;
+    shareText.value = shareableResult(current, completedGroups, count61, count67);
+    copyShareStatus.textContent = '';
 
     let verdict = 'Statistically significant brainrot.';
     if (current.wpm === 67) verdict = 'Exactly 67 WPM. The prophecy has cleared peer review.';
@@ -161,6 +191,8 @@
     stream.replaceChildren();
     stream.style.transform = '';
     result.hidden = true;
+    shareText.value = '';
+    copyShareStatus.textContent = '';
     appendGroups(120);
     timeEl.textContent = duration;
     wpmEl.textContent = '0';
@@ -171,6 +203,7 @@
 
   viewport.addEventListener('keydown', handleKey);
   document.getElementById('typing-restart').addEventListener('click', reset);
+  copyShareButton.addEventListener('click', copyShareResult);
   durationButtons.forEach((button) => {
     button.addEventListener('click', () => {
       duration = Number(button.dataset.duration);

--- a/brainrot/templates/brainrot/counter.html
+++ b/brainrot/templates/brainrot/counter.html
@@ -4,7 +4,7 @@
 {% block title %}67 Counter{% endblock %}
 
 {% block content %}
-<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260814.2">
+<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260814.3">
 {% if turnstile_enabled %}<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>{% endif %}
 
 <main class="br-page counter-page" id="counter-app"
@@ -67,7 +67,7 @@
       </fieldset>
 
       <button class="br-primary" id="enable-camera">Enable camera &amp; detector</button>
-      <button class="br-primary" id="start-run" disabled>Waiting for a visible pose…</button>
+      <button class="br-primary" id="start-run" disabled>Detector is still loading…</button>
       <button class="br-secondary" id="reset-run" hidden>Run this foolish experiment again</button>
       <p class="counter-error" id="counter-error" role="alert"></p>
     </aside>
@@ -102,5 +102,5 @@
 </main>
 
 {# Keep this version in step with counter.js so browsers cannot retain a broken runtime URL. #}
-<script type="module" src="{% static 'brainrot/counter.js' %}?v=20260814.2"></script>
+<script type="module" src="{% static 'brainrot/counter.js' %}?v=20260814.3"></script>
 {% endblock %}

--- a/brainrot/templates/brainrot/hall_of_fame.html
+++ b/brainrot/templates/brainrot/hall_of_fame.html
@@ -4,7 +4,7 @@
 {% block title %}67 Hall of Fame{% endblock %}
 
 {% block content %}
-<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}">
+<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260814.3">
 <main class="br-page hall-page">
   <header class="br-toolbar">
     <a href="{% url 'brainrot:counter' %}">← 67 Counter</a>
@@ -13,17 +13,8 @@
   <section class="hall-heading">
     <span class="br-kicker">PUBLIC ARCHIVE OF EXCEPTIONAL ARM ACTIVITY</span>
     <h1>67 Hall of Fame</h1>
-    <p>Scores appear only after a human checks the submitted evidence. Revolutionary stuff.</p>
+    <p>Valid uploads appear immediately. Obvious high-technology specimens may disappear without ceremony.</p>
   </section>
-
-  {% if own_pending %}
-  <section class="pending-panel">
-    <strong>Your pending peer review:</strong>
-    {% for entry in own_pending %}
-      <a href="{% url 'brainrot:hall_of_fame_video' entry.id %}" target="_blank">{{ entry.score }} points · {{ entry.created_at|date:'j M, H:i' }}</a>{% if not forloop.last %}<span>·</span>{% endif %}
-    {% endfor %}
-  </section>
-  {% endif %}
 
   <section class="hall-list">
     {% for entry in entries %}
@@ -41,8 +32,8 @@
     </article>
     {% empty %}
     <div class="empty-hall">
-      <strong>No verified legends yet.</strong>
-      <p>The scientific community remains unconvinced.</p>
+      <strong>No legends yet.</strong>
+      <p>The scientific community has uploaded absolutely nothing.</p>
       <a href="{% url 'brainrot:counter' %}" class="br-primary br-button-link">Submit the first specimen</a>
     </div>
     {% endfor %}

--- a/brainrot/templates/brainrot/typing.html
+++ b/brainrot/templates/brainrot/typing.html
@@ -4,7 +4,7 @@
 {% block title %}61 / 67 Typing Test{% endblock %}
 
 {% block content %}
-<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}">
+<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260814.3">
 <main class="br-page typing-page" id="typing-app">
   <header class="br-toolbar">
     <a href="{% url 'brainrot:index' %}">← Research division</a>
@@ -48,7 +48,13 @@
       <div><span>61 count</span><strong id="result-61">0</strong></div>
       <div><span>67 count</span><strong id="result-67">0</strong></div>
     </div>
+    <div class="counter-share typing-share">
+      <h3>🎉 Share your result!</h3>
+      <textarea id="typing-share-text" rows="5" readonly aria-label="Shareable typing result"></textarea>
+      <button class="br-secondary" id="copy-typing-share" type="button">Copy to clipboard</button>
+      <p class="subtle" id="copy-typing-status" role="status" aria-live="polite"></p>
+    </div>
   </section>
 </main>
-<script src="{% static 'brainrot/typing.js' %}" defer></script>
+<script src="{% static 'brainrot/typing.js' %}?v=20260814.3" defer></script>
 {% endblock %}

--- a/brainrot/tests.py
+++ b/brainrot/tests.py
@@ -19,8 +19,8 @@ class BrainrotPageTests(TestCase):
 
     def test_counter_uses_cache_busted_runtime_and_has_share_box(self):
         response = self.client.get('/67/')
-        self.assertContains(response, 'brainrot.css?v=20260814.2')
-        self.assertContains(response, 'counter.js?v=20260814.2')
+        self.assertContains(response, 'brainrot.css?v=20260814.3')
+        self.assertContains(response, 'counter.js?v=20260814.3')
         self.assertContains(response, 'id="counter-share-text"')
         self.assertContains(response, 'id="copy-counter-share"')
 
@@ -29,6 +29,17 @@ class BrainrotPageTests(TestCase):
         script = Path(script_path).read_text(encoding='utf-8')
         self.assertIn('@mediapipe/tasks-vision@1.0.1/vision_bundle.mjs', script)
         self.assertNotIn('@mediapipe/tasks-vision@0.10.26', script)
+
+    def test_typing_result_has_url_free_share_box(self):
+        response = self.client.get('/67/typing/')
+        self.assertContains(response, 'typing.js?v=20260814.3')
+        self.assertContains(response, 'id="typing-share-text"')
+        self.assertContains(response, 'id="copy-typing-share"')
+
+        script_path = finders.find('brainrot/typing.js')
+        script = Path(script_path).read_text(encoding='utf-8')
+        self.assertNotIn('window.location', script)
+        self.assertNotIn("new URL(", script)
 
 
 @override_settings(TURNSTILE_ENABLED=False, HOF_SUBMISSIONS_PER_HOUR=1)
@@ -49,15 +60,15 @@ class HallOfFameSubmissionTests(TestCase):
         self.assertEqual(HallOfFameEntry.objects.count(), 0)
 
     @patch('brainrot.views.validate_hall_of_fame_video')
-    def test_valid_upload_is_pending_and_rate_limited(self, validate):
+    def test_valid_upload_is_published_and_rate_limited(self, validate):
         validate.return_value = ValidatedVideo('video/webm', 'webm', 23.0)
         self.client.login(username='scientist', password='test-password-67')
         video = SimpleUploadedFile('run.webm', b'video evidence', content_type='video/webm')
         response = self.client.post('/67/submit/', {'score': 67, 'video': video})
         self.assertEqual(response.status_code, 201)
         entry = HallOfFameEntry.objects.get()
-        self.assertEqual(entry.state, HallOfFameEntry.State.PENDING)
-        self.assertFalse(self.client.get('/67/hall-of-fame/').context['entries'])
+        self.assertEqual(entry.state, HallOfFameEntry.State.APPROVED)
+        self.assertIn(entry, self.client.get('/67/hall-of-fame/').context['entries'])
 
         second = SimpleUploadedFile('run.webm', b'more evidence', content_type='video/webm')
         response = self.client.post('/67/submit/', {'score': 68, 'video': second})

--- a/brainrot/views.py
+++ b/brainrot/views.py
@@ -37,16 +37,7 @@ def hall_of_fame(request):
     entries = HallOfFameEntry.objects.filter(
         state=HallOfFameEntry.State.APPROVED,
     ).select_related('user')[:67]
-    own_pending = []
-    if request.user.is_authenticated:
-        own_pending = HallOfFameEntry.objects.filter(
-            user=request.user,
-            state=HallOfFameEntry.State.PENDING,
-        ).order_by('-created_at')[:5]
-    return render(request, 'brainrot/hall_of_fame.html', {
-        'entries': entries,
-        'own_pending': own_pending,
-    })
+    return render(request, 'brainrot/hall_of_fame.html', {'entries': entries})
 
 
 def _turnstile_is_valid(request):
@@ -113,6 +104,8 @@ def submit_hall_of_fame(request):
             score=score,
             mime_type=inspected.mime_type,
             duration_seconds=inspected.duration_seconds,
+            state=HallOfFameEntry.State.APPROVED,
+            reviewed_at=timezone.now(),
         )
         entry._validated_extension = inspected.extension
         entry.video = upload
@@ -122,7 +115,7 @@ def submit_hall_of_fame(request):
 
     return JsonResponse({
         'ok': True,
-        'message': 'Submitted for human review. Peer review has never been this important.',
+        'message': 'Published to the Hall of Fame. Peer review has been replaced by vibes.',
         'hall_of_fame_url': reverse('brainrot:hall_of_fame'),
     }, status=201)
 


### PR DESCRIPTION
## Summary

- add an OJ-style share box to the typing test without a URL
- change the Counter to an `I'm ready` arming flow, then automatically start the 3-second countdown after a stable pose is detected
- begin Hall of Fame recording only when the pose locks
- publish validated Hall of Fame uploads immediately instead of requiring manual approval
- retain login, Turnstile, rate, file-size, MIME, and duration protections
- retain admin deletion, including automatic deletion of the stored recording
- bump static asset versions and add regression coverage

## Verification

- `node --check brainrot/static/brainrot/counter.js`
- `node --check brainrot/static/brainrot/typing.js`
- `python manage.py check`
- `python manage.py makemigrations --check --dry-run`
- `python manage.py test brainrot oj` (8 tests passed)

No migration or new dependency is required. Run `python manage.py collectstatic --noinput` after merging.
