### PR TITLE
Fix 67 readiness and typing share link

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 - The retired OJ is controlled by `OJ_ENABLED` and defaults to `False`. Its code and database tables remain intact.
 - The 67 Counter uses the published MediaPipe Tasks Vision `1.0.1` browser bundle. It asks for camera permission before loading the pose runtime, and falls back from jsDelivr to unpkg if one CDN is filtered.
 - Counter CSS and JavaScript URLs are cache-busted in the template. If a browser still requests the nonexistent `@mediapipe/tasks-vision@0.10.26/+esm`, production is serving a stale collected static file: run `collectstatic`, reload the static server, and purge any reverse-proxy/CDN cache.
-- Hall of Fame videos require `ffprobe` (provided by the `ffmpeg` system package) for server-side duration/stream validation.
+- Hall of Fame videos require `ffprobe` for server-side duration/stream validation. On Raspberry Pi OS, Debian, or Ubuntu, install it with `sudo apt update && sudo apt install ffmpeg`, then verify with `ffprobe -version`.
 - Recordings are written to `PRIVATE_MEDIA_ROOT` (default: `private_media/`). Do **not** expose that directory as a public nginx/static alias; videos are served through a permission-checking Django route.
 - Enforce `client_max_body_size 26M;` (or the equivalent at the reverse proxy) in addition to the application-level 25 MiB limit.
 - Hall of Fame uploads require a logged-in account and are limited per account. For production, configure `TURNSTILE_SITE_KEY` and `TURNSTILE_SECRET_KEY` to add Cloudflare Turnstile with mandatory server-side verification.

--- a/brainrot/static/brainrot/counter.js
+++ b/brainrot/static/brainrot/counter.js
@@ -216,8 +216,13 @@ if (app) {
               startButton.textContent = 'Waiting for your pose…';
             }
           } else if (poseReady) {
+            startButton.disabled = false;
+            startButton.textContent = "I'm ready";
             setStatus('Pose detected — click I\'m ready, then take your position', 'ready');
           } else {
+            // Readiness is a user decision; a pose is required to start, not to arm the run.
+            startButton.disabled = false;
+            startButton.textContent = "I'm ready";
             setStatus('Detector ready — click I\'m ready, then step into frame', 'ready');
           }
         }

--- a/brainrot/static/brainrot/typing.js
+++ b/brainrot/static/brainrot/typing.js
@@ -89,7 +89,8 @@
     const verdict = current.wpm === 67
       ? 'The prophecy has cleared peer review.'
       : 'Statistically significant brainrot has occurred.';
-    return `I typed 61 / 67 at ${current.wpm} WPM with ${current.accuracy}% accuracy. 🧪\n${completedGroups} groups survived the keyboard\n61 × ${count61} | 67 × ${count67}\n${verdict}\nSIX SEVEN`;
+    const url = new URL('/67/typing/', window.location.origin).href;
+    return `I typed 61 / 67 at ${current.wpm} WPM with ${current.accuracy}% accuracy. 🧪\n${completedGroups} groups survived the keyboard\n61 × ${count61} | 67 × ${count67}\n${verdict}\nSIX SEVEN\n${url}`;
   }
 
   async function copyShareResult() {

--- a/brainrot/templates/brainrot/counter.html
+++ b/brainrot/templates/brainrot/counter.html
@@ -102,5 +102,5 @@
 </main>
 
 {# Keep this version in step with counter.js so browsers cannot retain a broken runtime URL. #}
-<script type="module" src="{% static 'brainrot/counter.js' %}?v=20260814.3"></script>
+<script type="module" src="{% static 'brainrot/counter.js' %}?v=20260814.4"></script>
 {% endblock %}

--- a/brainrot/templates/brainrot/typing.html
+++ b/brainrot/templates/brainrot/typing.html
@@ -56,5 +56,5 @@
     </div>
   </section>
 </main>
-<script src="{% static 'brainrot/typing.js' %}?v=20260814.3" defer></script>
+<script src="{% static 'brainrot/typing.js' %}?v=20260814.4" defer></script>
 {% endblock %}

--- a/brainrot/tests.py
+++ b/brainrot/tests.py
@@ -20,7 +20,7 @@ class BrainrotPageTests(TestCase):
     def test_counter_uses_cache_busted_runtime_and_has_share_box(self):
         response = self.client.get('/67/')
         self.assertContains(response, 'brainrot.css?v=20260814.3')
-        self.assertContains(response, 'counter.js?v=20260814.3')
+        self.assertContains(response, 'counter.js?v=20260814.4')
         self.assertContains(response, 'id="counter-share-text"')
         self.assertContains(response, 'id="copy-counter-share"')
 
@@ -29,17 +29,18 @@ class BrainrotPageTests(TestCase):
         script = Path(script_path).read_text(encoding='utf-8')
         self.assertIn('@mediapipe/tasks-vision@1.0.1/vision_bundle.mjs', script)
         self.assertNotIn('@mediapipe/tasks-vision@0.10.26', script)
+        self.assertIn("startButton.disabled = false;", script)
+        self.assertIn("if (poseReady) {\n              beginRun();", script)
 
-    def test_typing_result_has_url_free_share_box(self):
+    def test_typing_result_has_share_box_and_url(self):
         response = self.client.get('/67/typing/')
-        self.assertContains(response, 'typing.js?v=20260814.3')
+        self.assertContains(response, 'typing.js?v=20260814.4')
         self.assertContains(response, 'id="typing-share-text"')
         self.assertContains(response, 'id="copy-typing-share"')
 
         script_path = finders.find('brainrot/typing.js')
         script = Path(script_path).read_text(encoding='utf-8')
-        self.assertNotIn('window.location', script)
-        self.assertNotIn("new URL(", script)
+        self.assertIn("new URL('/67/typing/', window.location.origin)", script)
 
 
 @override_settings(TURNSTILE_ENABLED=False, HOF_SUBMISSIONS_PER_HOUR=1)


### PR DESCRIPTION
## Summary

- keep `I'm ready` explicitly enabled before any pose is visible once the detector has loaded
- preserve the armed flow: the first stable pose starts the countdown automatically
- append the canonical `/67/typing/` URL to typing-test share text
- bump both script cache versions
- document the Raspberry Pi/Debian `ffprobe` installation command
- add regression coverage for readiness and the typing URL

## Verification

- `node --check brainrot/static/brainrot/counter.js`
- `node --check brainrot/static/brainrot/typing.js`
- `python manage.py check`
- `python manage.py makemigrations --check --dry-run`
- `python manage.py test brainrot oj` (8 tests passed)

No migration or Python dependency is required. Run `python manage.py collectstatic --noinput` after merging. Hall of Fame video validation additionally requires the system package `ffmpeg`, which supplies `ffprobe`.
