### PR TITLE
Make /67 the 61/67 Lab hub

### DIFF
--- a/brainrot/static/brainrot/counter.js
+++ b/brainrot/static/brainrot/counter.js
@@ -95,7 +95,7 @@ if (app) {
     const blocks = score > 0
       ? `${'🟩'.repeat(Math.min(score, 67))}${score > 67 ? ` +${score - 67}` : ''}`
       : '⬜';
-    const url = new URL('/67/', window.location.origin).href;
+    const url = new URL('/67/counter/', window.location.origin).href;
     return `${headline}\n20 seconds of arm-based research\n${blocks}\nSIX SEVEN\nCan you do better?\n${url}`;
   }
 

--- a/brainrot/templates/brainrot/counter.html
+++ b/brainrot/templates/brainrot/counter.html
@@ -102,5 +102,5 @@
 </main>
 
 {# Keep this version in step with counter.js so browsers cannot retain a broken runtime URL. #}
-<script type="module" src="{% static 'brainrot/counter.js' %}?v=20260814.4"></script>
+<script type="module" src="{% static 'brainrot/counter.js' %}?v=20260814.5"></script>
 {% endblock %}

--- a/brainrot/tests.py
+++ b/brainrot/tests.py
@@ -13,14 +13,18 @@ from .validators import ValidatedVideo
 
 class BrainrotPageTests(TestCase):
     def test_public_pages_load(self):
-        for path in ('/67/', '/67/games/', '/67/hall-of-fame/', '/67/typing/'):
+        for path in ('/67/', '/67/counter/', '/67/hall-of-fame/', '/67/typing/'):
             with self.subTest(path=path):
                 self.assertEqual(self.client.get(path).status_code, 200)
 
+        legacy = self.client.get('/67/games/')
+        self.assertEqual(legacy.status_code, 301)
+        self.assertEqual(legacy['Location'], '/67/')
+
     def test_counter_uses_cache_busted_runtime_and_has_share_box(self):
-        response = self.client.get('/67/')
+        response = self.client.get('/67/counter/')
         self.assertContains(response, 'brainrot.css?v=20260814.3')
-        self.assertContains(response, 'counter.js?v=20260814.4')
+        self.assertContains(response, 'counter.js?v=20260814.5')
         self.assertContains(response, 'id="counter-share-text"')
         self.assertContains(response, 'id="copy-counter-share"')
 
@@ -31,6 +35,7 @@ class BrainrotPageTests(TestCase):
         self.assertNotIn('@mediapipe/tasks-vision@0.10.26', script)
         self.assertIn("startButton.disabled = false;", script)
         self.assertIn("if (poseReady) {\n              beginRun();", script)
+        self.assertIn("new URL('/67/counter/', window.location.origin)", script)
 
     def test_typing_result_has_share_box_and_url(self):
         response = self.client.get('/67/typing/')

--- a/brainrot/urls.py
+++ b/brainrot/urls.py
@@ -1,12 +1,14 @@
 from django.urls import path
+from django.views.generic import RedirectView
 
 from . import views
 
 app_name = 'brainrot'
 
 urlpatterns = [
-    path('', views.counter, name='counter'),
-    path('games/', views.index, name='index'),
+    path('', views.index, name='index'),
+    path('counter/', views.counter, name='counter'),
+    path('games/', RedirectView.as_view(pattern_name='brainrot:index', permanent=True), name='games_legacy'),
     path('submit/', views.submit_hall_of_fame, name='submit_hall_of_fame'),
     path('hall-of-fame/', views.hall_of_fame, name='hall_of_fame'),
     path('hall-of-fame/<int:entry_id>/video/', views.hall_of_fame_video, name='hall_of_fame_video'),

--- a/homepage/templates/homepage/index.html
+++ b/homepage/templates/homepage/index.html
@@ -115,7 +115,7 @@
                 <a href="/blog">{% trans "blog" %}</a>,
                 <a href="/orac-leaderboards">ORAC Leaderboards++</a>,
                 {% trans "or" %}
-                <a href="{% url 'brainrot:counter' %}">61/67 Research Division</a>.
+                <a href="{% url 'brainrot:index' %}">61/67 Research Division</a>.
             </p>
         </div>
     </div>
@@ -133,7 +133,7 @@
         <a href="/oracdata" class="nav-card btn-analytics">
             📊 {% trans "ORAC2 Analytics" %}
         </a>
-        <a href="{% url 'brainrot:counter' %}" class="nav-card btn-brainrot">
+        <a href="{% url 'brainrot:index' %}" class="nav-card btn-brainrot">
             🧪 61/67 Research Division
         </a>
     </div>

--- a/templates/base.html
+++ b/templates/base.html
@@ -64,7 +64,7 @@
               <a class="nav-link" href="/orac-leaderboards"><i class="fa-solid fa-ranking-star"></i> ORAC LB</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="{% url 'brainrot:counter' %}"><i class="fa-solid fa-flask"></i> 61/67 Lab</a>
+              <a class="nav-link" href="{% url 'brainrot:index' %}"><i class="fa-solid fa-flask"></i> 61/67 Lab</a>
             </li>
             <li class="nav-item">
               <a class="nav-link" href="/oj"><i class="fa-solid fa-box-archive"></i> {% trans 'OJ' %}</a>


### PR DESCRIPTION
## Summary

- make `/67/` the 61/67 Lab hub as originally intended
- move the camera Counter to `/67/counter/`
- permanently redirect the legacy `/67/games/` route to `/67/`
- update the global navigation and homepage cards to link to the Lab hub
- update Counter result sharing to use its new canonical URL
- bump the Counter script cache version and add route regression coverage

## Root cause

The earlier route change interpreted “entry at `/67`” as placing the Counter itself there. The repository therefore deliberately mapped the empty app path to `views.counter`; this was not a Git or deployment failure.

## Verification

- `node --check brainrot/static/brainrot/counter.js`
- `python manage.py check`
- `python manage.py makemigrations --check --dry-run`
- `python manage.py test brainrot oj` (8 tests passed)
- Django reverse check: hub `/67/`, Counter `/67/counter/`, legacy `/67/games/`

No migration or dependency is required. Run `python manage.py collectstatic --noinput` after merging.
