### PR TITLE
Improve 67 runtime, counting, and recordings

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 - Recordings are written to `PRIVATE_MEDIA_ROOT` (default: `private_media/`). Do **not** expose that directory as a public nginx/static alias; videos are served through a permission-checking Django route.
 - Enforce `client_max_body_size 26M;` (or the equivalent at the reverse proxy) in addition to the application-level 25 MiB limit.
 - Hall of Fame uploads require a logged-in account and are limited per account. For production, configure `TURNSTILE_SITE_KEY` and `TURNSTILE_SECRET_KEY` to add Cloudflare Turnstile with mandatory server-side verification.
-- The default Hall of Fame rate limit is 3 attempts per authenticated account in a rolling hour. Failed Turnstile, score, and video-validation attempts count too; override it with `HOF_SUBMISSIONS_PER_HOUR`.
+- The default Hall of Fame rate limit is 3 attempts per authenticated account in a rolling minute. Failed Turnstile, score, and video-validation attempts count too; override it with `HOF_SUBMISSIONS_PER_MINUTE`.
 - Valid Hall of Fame uploads are published immediately. Delete obvious fake or abusive entries in Django admin; deleting an entry also deletes its private recording.
 
 Deploy database/static changes with:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - Recordings are written to `PRIVATE_MEDIA_ROOT` (default: `private_media/`). Do **not** expose that directory as a public nginx/static alias; videos are served through a permission-checking Django route.
 - Enforce `client_max_body_size 26M;` (or the equivalent at the reverse proxy) in addition to the application-level 25 MiB limit.
 - Hall of Fame uploads require a logged-in account and are limited per account. For production, configure `TURNSTILE_SITE_KEY` and `TURNSTILE_SECRET_KEY` to add Cloudflare Turnstile with mandatory server-side verification.
+- The default Hall of Fame rate limit is 3 attempts per authenticated account in a rolling hour. Failed Turnstile, score, and video-validation attempts count too; override it with `HOF_SUBMISSIONS_PER_HOUR`.
 - Valid Hall of Fame uploads are published immediately. Delete obvious fake or abusive entries in Django admin; deleting an entry also deletes its private recording.
 
 Deploy database/static changes with:

--- a/brainrot/admin.py
+++ b/brainrot/admin.py
@@ -18,7 +18,12 @@ class HallOfFameEntryAdmin(admin.ModelAdmin):
     def review_video(self, obj):
         if not obj.pk:
             return 'Save first'
-        return format_html('<a href="{}" target="_blank">Open private recording</a>', f'/67/hall-of-fame/{obj.pk}/video/')
+        video_url = f'/67/hall-of-fame/{obj.pk}/video/'
+        return format_html(
+            '<a href="{}" target="_blank">Open recording</a> · <a href="{}?download=1">Download</a>',
+            video_url,
+            video_url,
+        )
 
     @admin.action(description='Approve selected entries')
     def approve_entries(self, request, queryset):

--- a/brainrot/static/brainrot/brainrot.css
+++ b/brainrot/static/brainrot/brainrot.css
@@ -21,6 +21,8 @@
   font-family: Inter, ui-sans-serif, system-ui, -apple-system, sans-serif;
 }
 
+.br-page [hidden] { display: none !important; }
+
 .br-kicker {
   color: #475569;
   font-size: .72rem;
@@ -158,6 +160,7 @@
 .result-card h2 { margin-top: .4rem; font-weight: 900; }
 .recording-review video { width: 100%; max-height: 310px; border-radius: 12px; background: #111827; }
 .recording-review p { color: var(--br-muted); font-size: .85rem; }
+.recording-download { margin-bottom: .7rem; }
 .counter-share { grid-column: 1 / -1; padding-top: 1.25rem; border-top: 1px solid var(--br-line); }
 .counter-share h3 { margin: 0 0 .75rem; font-size: 1rem; font-weight: 850; text-align: center; }
 .counter-share textarea {
@@ -220,6 +223,7 @@
 .hall-entry details { text-align: right; }
 .hall-entry summary { cursor: pointer; color: var(--br-accent-dark); font-size: .86rem; font-weight: 800; }
 .hall-entry video { width: min(420px, 75vw); max-height: 300px; margin-top: .7rem; border-radius: 10px; background: #111827; }
+.hall-download { display: block; width: fit-content; margin: .45rem 0 0 auto; color: var(--br-ink); font-size: .8rem; font-weight: 750; }
 .empty-hall { padding: 4rem 1.5rem; text-align: center; }
 .empty-hall strong { font-size: 1.5rem; }
 .empty-hall p { color: var(--br-muted); }

--- a/brainrot/static/brainrot/counter.js
+++ b/brainrot/static/brainrot/counter.js
@@ -31,6 +31,7 @@ if (app) {
   const GO_DISPLAY_MS = 250;
   let stream = null;
   let landmarker = null;
+  let runtimePromise = null;
   let detectorLoop = null;
   let gameLoop = null;
   let lastVideoTime = -1;
@@ -70,6 +71,48 @@ if (app) {
       }
     }
     throw new Error(`Could not load the pose runtime from either CDN: ${lastError?.message || 'network blocked'}`);
+  }
+
+  function initialisePoseRuntime() {
+    if (landmarker) return Promise.resolve(landmarker);
+    if (!runtimePromise) {
+      runtimePromise = (async () => {
+        const { FilesetResolver, PoseLandmarker, wasmRoot } = await loadMediaPipe();
+        const vision = await FilesetResolver.forVisionTasks(wasmRoot);
+        const options = {
+          baseOptions: {
+            modelAssetPath: 'https://storage.googleapis.com/mediapipe-models/pose_landmarker/pose_landmarker_lite/float16/1/pose_landmarker_lite.task',
+            delegate: 'GPU',
+          },
+          runningMode: 'VIDEO',
+          numPoses: 1,
+          minPoseDetectionConfidence: 0.55,
+          minPosePresenceConfidence: 0.55,
+          minTrackingConfidence: 0.55,
+        };
+        try {
+          landmarker = await PoseLandmarker.createFromOptions(vision, options);
+        } catch (gpuError) {
+          options.baseOptions.delegate = 'CPU';
+          landmarker = await PoseLandmarker.createFromOptions(vision, options);
+        }
+        return landmarker;
+      })().catch((error) => {
+        runtimePromise = null;
+        throw error;
+      });
+    }
+    return runtimePromise;
+  }
+
+  function preloadPoseRuntime() {
+    setStatus('Preloading pose model — camera remains off', 'busy');
+    initialisePoseRuntime().then(() => {
+      if (!stream) setStatus('Pose model ready — camera remains off', 'ready');
+    }).catch((error) => {
+      if (!stream) setStatus('Pose model preload paused — camera remains off');
+      console.warn('Pose runtime preload failed; the camera button will retry it.', error);
+    });
   }
 
   function setStatus(message, state = '') {
@@ -248,27 +291,8 @@ if (app) {
       video.srcObject = stream;
       await video.play();
       placeholder.hidden = true;
-      setStatus('Loading the pose model into this browser…', 'busy');
-
-      const { FilesetResolver, PoseLandmarker, wasmRoot } = await loadMediaPipe();
-      const vision = await FilesetResolver.forVisionTasks(wasmRoot);
-      const options = {
-        baseOptions: {
-          modelAssetPath: 'https://storage.googleapis.com/mediapipe-models/pose_landmarker/pose_landmarker_lite/float16/1/pose_landmarker_lite.task',
-          delegate: 'GPU',
-        },
-        runningMode: 'VIDEO',
-        numPoses: 1,
-        minPoseDetectionConfidence: 0.55,
-        minPosePresenceConfidence: 0.55,
-        minTrackingConfidence: 0.55,
-      };
-      try {
-        landmarker = await PoseLandmarker.createFromOptions(vision, options);
-      } catch (gpuError) {
-        options.baseOptions.delegate = 'CPU';
-        landmarker = await PoseLandmarker.createFromOptions(vision, options);
-      }
+      setStatus(landmarker ? 'Pose model ready' : 'Finishing pose model preload…', 'busy');
+      await initialisePoseRuntime();
       enableButton.hidden = true;
       startButton.disabled = false;
       startButton.textContent = "I'm ready";
@@ -480,6 +504,7 @@ if (app) {
       });
     });
   });
+  preloadPoseRuntime();
   enableButton.addEventListener('click', initialiseDetector);
   startButton.addEventListener('click', armRun);
   resetButton.addEventListener('click', resetRun);

--- a/brainrot/static/brainrot/counter.js
+++ b/brainrot/static/brainrot/counter.js
@@ -21,6 +21,7 @@ if (app) {
   const copyShareStatus = document.getElementById('copy-counter-status');
   const recordingReview = document.getElementById('recording-review');
   const recordingPreview = document.getElementById('recording-preview');
+  const recordingDownload = document.getElementById('download-recording');
   const submitButton = document.getElementById('submit-hof');
   const discardButton = document.getElementById('discard-recording');
   const uploadStatus = document.getElementById('upload-status');
@@ -209,7 +210,9 @@ if (app) {
 
   function sufficientlyVisible(landmarks) {
     if (!landmarks) return false;
-    return [11, 12, 13, 14, 15, 16].every((id) => {
+    // Elbows improve the overlay but do not participate in the counter. A
+    // briefly uncertain elbow should not discard an otherwise usable frame.
+    return [11, 12, 15, 16].every((id) => {
       const point = landmarks[id];
       return point && (point.visibility ?? 1) > 0.45 && point.x > 0.02 && point.x < 0.98 && point.y > 0.02 && point.y < 0.98;
     });
@@ -428,6 +431,9 @@ if (app) {
       if (recordingUrl) URL.revokeObjectURL(recordingUrl);
       recordingUrl = URL.createObjectURL(blob);
       recordingPreview.src = recordingUrl;
+      recordingDownload.href = recordingUrl;
+      recordingDownload.download = blob.type === 'video/mp4' ? '67-run.mp4' : '67-run.webm';
+      recordingDownload.hidden = false;
     }
     resetButton.hidden = false;
     resultCard.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
@@ -439,6 +445,8 @@ if (app) {
     recordingBlob = null;
     recordingPreview.removeAttribute('src');
     recordingPreview.load();
+    recordingDownload.removeAttribute('href');
+    recordingDownload.hidden = true;
     recordingReview.hidden = true;
     if (uploadStatus) uploadStatus.textContent = 'Recording discarded. Nothing was uploaded.';
   }

--- a/brainrot/static/brainrot/counter.js
+++ b/brainrot/static/brainrot/counter.js
@@ -27,6 +27,8 @@ if (app) {
   const modeInputs = [...document.querySelectorAll('input[name="mode"]')];
 
   const GAME_SECONDS = 20;
+  const COUNTDOWN_STEP_MS = 1000;
+  const GO_DISPLAY_MS = 250;
   let stream = null;
   let landmarker = null;
   let detectorLoop = null;
@@ -368,10 +370,10 @@ if (app) {
 
     for (const value of ['3', '2', '1']) {
       countdownEl.textContent = value;
-      await delay(700);
+      await delay(COUNTDOWN_STEP_MS);
     }
     countdownEl.textContent = 'GO';
-    await delay(350);
+    await delay(GO_DISPLAY_MS);
     countdownEl.textContent = '';
     countdownActive = false;
     running = true;

--- a/brainrot/templates/brainrot/counter.html
+++ b/brainrot/templates/brainrot/counter.html
@@ -102,5 +102,5 @@
 </main>
 
 {# Keep this version in step with counter.js so browsers cannot retain a broken runtime URL. #}
-<script type="module" src="{% static 'brainrot/counter.js' %}?v=20260814.5"></script>
+<script type="module" src="{% static 'brainrot/counter.js' %}?v=20260814.6"></script>
 {% endblock %}

--- a/brainrot/templates/brainrot/counter.html
+++ b/brainrot/templates/brainrot/counter.html
@@ -4,6 +4,8 @@
 {% block title %}67 Counter{% endblock %}
 
 {% block content %}
+<link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+<link rel="preconnect" href="https://storage.googleapis.com" crossorigin>
 <link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260814.3">
 {% if turnstile_enabled %}<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>{% endif %}
 
@@ -43,7 +45,7 @@
       </div>
       <div class="detector-status" id="detector-status">
         <span class="status-dot"></span>
-        <span>Camera not started</span>
+        <span>Preloading pose model — camera remains off</span>
       </div>
     </div>
 
@@ -66,7 +68,7 @@
         </label>
       </fieldset>
 
-      <button class="br-primary" id="enable-camera">Enable camera &amp; detector</button>
+      <button class="br-primary" id="enable-camera">Enable camera</button>
       <button class="br-primary" id="start-run" disabled>Detector is still loading…</button>
       <button class="br-secondary" id="reset-run" hidden>Run this foolish experiment again</button>
       <p class="counter-error" id="counter-error" role="alert"></p>
@@ -102,5 +104,5 @@
 </main>
 
 {# Keep this version in step with counter.js so browsers cannot retain a broken runtime URL. #}
-<script type="module" src="{% static 'brainrot/counter.js' %}?v=20260814.6"></script>
+<script type="module" src="{% static 'brainrot/counter.js' %}?v=20260814.7"></script>
 {% endblock %}

--- a/brainrot/templates/brainrot/counter.html
+++ b/brainrot/templates/brainrot/counter.html
@@ -6,7 +6,7 @@
 {% block content %}
 <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
 <link rel="preconnect" href="https://storage.googleapis.com" crossorigin>
-<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260814.3">
+<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260814.4">
 {% if turnstile_enabled %}<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>{% endif %}
 
 <main class="br-page counter-page" id="counter-app"
@@ -84,6 +84,7 @@
     <div class="recording-review" id="recording-review" hidden>
       <video id="recording-preview" controls playsinline></video>
       <p>The recording remains local unless you submit it below. Closing or resetting discards it.</p>
+      <a class="br-secondary br-button-link recording-download" id="download-recording" hidden>Download this recording</a>
       {% if request.user.is_authenticated %}
         {% if turnstile_enabled %}<div class="cf-turnstile" data-sitekey="{{ turnstile_site_key }}"></div>{% endif %}
         <button class="br-primary" id="submit-hof">Submit to Hall of Fame</button>
@@ -104,5 +105,5 @@
 </main>
 
 {# Keep this version in step with counter.js so browsers cannot retain a broken runtime URL. #}
-<script type="module" src="{% static 'brainrot/counter.js' %}?v=20260814.7"></script>
+<script type="module" src="{% static 'brainrot/counter.js' %}?v=20260814.8"></script>
 {% endblock %}

--- a/brainrot/templates/brainrot/hall_of_fame.html
+++ b/brainrot/templates/brainrot/hall_of_fame.html
@@ -4,7 +4,7 @@
 {% block title %}67 Hall of Fame{% endblock %}
 
 {% block content %}
-<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260814.3">
+<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260814.4">
 <main class="br-page hall-page">
   <header class="br-toolbar">
     <a href="{% url 'brainrot:counter' %}">← 67 Counter</a>
@@ -26,8 +26,10 @@
       </div>
       <strong class="hall-score">{{ entry.score }}</strong>
       <details>
+        {% url 'brainrot:hall_of_fame_video' entry.id as evidence_url %}
         <summary>Watch the evidence</summary>
-        <video controls preload="none" playsinline src="{% url 'brainrot:hall_of_fame_video' entry.id %}"></video>
+        <video controls preload="none" playsinline src="{{ evidence_url }}"></video>
+        <a class="hall-download" href="{{ evidence_url }}?download=1">Download evidence</a>
       </details>
     </article>
     {% empty %}

--- a/brainrot/tests.py
+++ b/brainrot/tests.py
@@ -1,5 +1,6 @@
 import tempfile
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
@@ -8,7 +9,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase, override_settings
 
 from .models import HallOfFameEntry
-from .validators import ValidatedVideo
+from .validators import ValidatedVideo, _packet_duration
 
 
 class BrainrotPageTests(TestCase):
@@ -24,7 +25,7 @@ class BrainrotPageTests(TestCase):
     def test_counter_uses_cache_busted_runtime_and_has_share_box(self):
         response = self.client.get('/67/counter/')
         self.assertContains(response, 'brainrot.css?v=20260814.3')
-        self.assertContains(response, 'counter.js?v=20260814.5')
+        self.assertContains(response, 'counter.js?v=20260814.6')
         self.assertContains(response, 'id="counter-share-text"')
         self.assertContains(response, 'id="copy-counter-share"')
 
@@ -36,6 +37,16 @@ class BrainrotPageTests(TestCase):
         self.assertIn("startButton.disabled = false;", script)
         self.assertIn("if (poseReady) {\n              beginRun();", script)
         self.assertIn("new URL('/67/counter/', window.location.origin)", script)
+
+
+class VideoValidationTests(TestCase):
+    @patch('brainrot.validators.subprocess.run')
+    def test_packet_duration_uses_span_not_absolute_camera_timestamp(self, run):
+        run.return_value = SimpleNamespace(
+            returncode=0,
+            stdout='87.000000,0.033333\n109.966667,0.033333\n',
+        )
+        self.assertAlmostEqual(_packet_duration('/tmp/run.webm', '/usr/bin/ffprobe'), 23.0)
 
     def test_typing_result_has_share_box_and_url(self):
         response = self.client.get('/67/typing/')

--- a/brainrot/tests.py
+++ b/brainrot/tests.py
@@ -25,7 +25,7 @@ class BrainrotPageTests(TestCase):
     def test_counter_uses_cache_busted_runtime_and_has_share_box(self):
         response = self.client.get('/67/counter/')
         self.assertContains(response, 'brainrot.css?v=20260814.3')
-        self.assertContains(response, 'counter.js?v=20260814.6')
+        self.assertContains(response, 'counter.js?v=20260814.7')
         self.assertContains(response, 'id="counter-share-text"')
         self.assertContains(response, 'id="copy-counter-share"')
 
@@ -37,6 +37,8 @@ class BrainrotPageTests(TestCase):
         self.assertIn("startButton.disabled = false;", script)
         self.assertIn("if (poseReady) {\n              beginRun();", script)
         self.assertIn("new URL('/67/counter/', window.location.origin)", script)
+        self.assertIn('preloadPoseRuntime();', script)
+        self.assertLess(script.index('preloadPoseRuntime();'), script.index("enableButton.addEventListener('click'"))
 
 
 class VideoValidationTests(TestCase):
@@ -59,7 +61,7 @@ class VideoValidationTests(TestCase):
         self.assertIn("new URL('/67/typing/', window.location.origin)", script)
 
 
-@override_settings(TURNSTILE_ENABLED=False, HOF_SUBMISSIONS_PER_HOUR=1)
+@override_settings(TURNSTILE_ENABLED=False, HOF_SUBMISSIONS_PER_MINUTE=1)
 class HallOfFameSubmissionTests(TestCase):
     def setUp(self):
         self.private_directory = tempfile.TemporaryDirectory()

--- a/brainrot/tests.py
+++ b/brainrot/tests.py
@@ -24,10 +24,11 @@ class BrainrotPageTests(TestCase):
 
     def test_counter_uses_cache_busted_runtime_and_has_share_box(self):
         response = self.client.get('/67/counter/')
-        self.assertContains(response, 'brainrot.css?v=20260814.3')
-        self.assertContains(response, 'counter.js?v=20260814.7')
+        self.assertContains(response, 'brainrot.css?v=20260814.4')
+        self.assertContains(response, 'counter.js?v=20260814.8')
         self.assertContains(response, 'id="counter-share-text"')
         self.assertContains(response, 'id="copy-counter-share"')
+        self.assertContains(response, 'id="download-recording"')
 
         script_path = finders.find('brainrot/counter.js')
         self.assertIsNotNone(script_path)
@@ -39,6 +40,7 @@ class BrainrotPageTests(TestCase):
         self.assertIn("new URL('/67/counter/', window.location.origin)", script)
         self.assertIn('preloadPoseRuntime();', script)
         self.assertLess(script.index('preloadPoseRuntime();'), script.index("enableButton.addEventListener('click'"))
+        self.assertIn('return [11, 12, 15, 16].every', script)
 
 
 class VideoValidationTests(TestCase):
@@ -111,3 +113,7 @@ class HallOfFameSubmissionTests(TestCase):
         entry.state = HallOfFameEntry.State.APPROVED
         entry.save(update_fields=['state'])
         self.assertEqual(self.client.get(path).status_code, 200)
+
+        download = self.client.get(f'{path}?download=1')
+        self.assertEqual(download.status_code, 200)
+        self.assertTrue(download['Content-Disposition'].startswith('attachment;'))

--- a/brainrot/validators.py
+++ b/brainrot/validators.py
@@ -31,16 +31,23 @@ def _packet_duration(path, ffprobe):
     )
     if completed.returncode != 0:
         return 0
-    end_time = 0.0
+    first_pts = None
+    end_time = None
     for line in completed.stdout.splitlines():
         values = line.split(',')
         try:
             pts = float(values[0])
             packet_duration = float(values[1]) if len(values) > 1 and values[1] else 0
-            end_time = max(end_time, pts + packet_duration)
+            first_pts = pts if first_pts is None else min(first_pts, pts)
+            packet_end = pts + packet_duration
+            end_time = packet_end if end_time is None else max(end_time, packet_end)
         except ValueError:
             continue
-    return end_time
+    if first_pts is None or end_time is None:
+        return 0
+    # MediaRecorder packets may retain timestamps from the long-lived camera
+    # stream. Duration is the packet span, not the final absolute PTS.
+    return max(0, end_time - first_pts)
 
 
 def _sniff_container(upload):

--- a/brainrot/views.py
+++ b/brainrot/views.py
@@ -132,7 +132,8 @@ def hall_of_fame_video(request, entry_id):
 
     response = FileResponse(entry.video.open('rb'), content_type=entry.mime_type)
     response['Content-Length'] = entry.video.size
-    response['Content-Disposition'] = f'inline; filename="67-run-{entry.pk}.{entry.video.name.rsplit(".", 1)[-1]}"'
+    disposition = 'attachment' if request.GET.get('download') == '1' else 'inline'
+    response['Content-Disposition'] = f'{disposition}; filename="67-run-{entry.pk}.{entry.video.name.rsplit(".", 1)[-1]}"'
     response['X-Content-Type-Options'] = 'nosniff'
     response['Cache-Control'] = 'private, max-age=300'
     return response

--- a/brainrot/views.py
+++ b/brainrot/views.py
@@ -70,12 +70,12 @@ def _turnstile_is_valid(request):
 @require_POST
 @login_required
 def submit_hall_of_fame(request):
-    recent_cutoff = timezone.now() - timedelta(hours=1)
+    recent_cutoff = timezone.now() - timedelta(minutes=1)
     recent_count = HallOfFameUploadAttempt.objects.filter(
         user=request.user,
         created_at__gte=recent_cutoff,
     ).count()
-    if recent_count >= settings.HOF_SUBMISSIONS_PER_HOUR:
+    if recent_count >= settings.HOF_SUBMISSIONS_PER_MINUTE:
         return JsonResponse({'error': 'Rate limit reached. The Institute requests patience.'}, status=429)
 
     attempt = HallOfFameUploadAttempt.objects.create(user=request.user)

--- a/myblog/settings.py
+++ b/myblog/settings.py
@@ -151,7 +151,7 @@ OJ_ENABLED = os.getenv('OJ_ENABLED', 'False') == 'True'
 PRIVATE_MEDIA_ROOT = Path(os.getenv('PRIVATE_MEDIA_ROOT', BASE_DIR / 'private_media'))
 HOF_MAX_UPLOAD_BYTES = int(os.getenv('HOF_MAX_UPLOAD_BYTES', 25 * 1024 * 1024))
 HOF_MAX_VIDEO_SECONDS = float(os.getenv('HOF_MAX_VIDEO_SECONDS', 26))
-HOF_SUBMISSIONS_PER_HOUR = int(os.getenv('HOF_SUBMISSIONS_PER_HOUR', 3))
+HOF_SUBMISSIONS_PER_MINUTE = int(os.getenv('HOF_SUBMISSIONS_PER_MINUTE', 3))
 
 # Optional but recommended in production.  If both values are present the
 # Hall of Fame upload endpoint requires a server-verified Turnstile token.


### PR DESCRIPTION
## Summary

- preload the MediaPipe JS, WASM, lite pose model, and PoseLandmarker as soon as the Counter page loads while keeping the camera off
- use real one-second 3–2–1 countdown steps and fix WebM packet-duration measurement
- change the default rate to 3 attempts/minute per authenticated account
- stop discarding counting frames merely because an unused elbow landmark has low confidence
- add download controls for the local post-run recording, public Hall of Fame evidence, and Django admin
- serve explicit attachment responses for stored-video downloads while retaining the existing visibility checks
- bump Counter/CSS asset versions and add regression tests

## Counting adjustment

Only shoulders and wrists determine the relative-height gesture. Elbows remain in the visual skeleton overlay, but no longer gate whether a frame may count.

## Runtime details

The first load transfers roughly 155 KB of JavaScript, 11.8 MB of WASM, and a 5.8 MB lite pose model, then initialises the runtime. Preloading hides that work behind page reading and camera permission without accessing camera frames.

## Protection

- 3 attempts per authenticated account in a rolling minute by default
- failed Turnstile, score, and video-validation attempts count
- 25 MiB request/file and 26-second video limits
- container, MIME, codec, and video-stream validation
- download requests use the same approved/owner/staff permission check as inline playback

## Verification

- `node --check brainrot/static/brainrot/counter.js`
- `python manage.py check`
- `python manage.py makemigrations --check --dry-run`
- `python manage.py test brainrot oj` (9 tests passed)

No migration or dependency is required. The optional override is `HOF_SUBMISSIONS_PER_MINUTE`. Run `python manage.py collectstatic --noinput` after merging.
