### PR TITLE
Unify casual and Hall of Fame runs

### DIFF
--- a/brainrot/static/brainrot/brainrot.css
+++ b/brainrot/static/brainrot/brainrot.css
@@ -156,6 +156,7 @@
 .br-button-link:hover { color: white; }
 .br-text-button { display: block; margin: .7rem auto 0; border: 0; background: transparent; color: var(--br-muted); text-decoration: underline; }
 .counter-error { min-height: 1.3rem; margin: .8rem 0 0; color: #b91c1c; font-size: .85rem; }
+.run-consent { margin: .65rem .15rem 0; text-align: center; }
 .result-card { display: grid; grid-template-columns: 1fr 1fr; gap: 2rem; margin-top: 1.25rem; padding: 1.5rem; }
 .result-card h2 { margin-top: .4rem; font-weight: 900; }
 .recording-review video { width: 100%; max-height: 310px; border-radius: 12px; background: #111827; }

--- a/brainrot/static/brainrot/counter.js
+++ b/brainrot/static/brainrot/counter.js
@@ -25,11 +25,11 @@ if (app) {
   const submitButton = document.getElementById('submit-hof');
   const discardButton = document.getElementById('discard-recording');
   const uploadStatus = document.getElementById('upload-status');
-  const modeInputs = [...document.querySelectorAll('input[name="mode"]')];
 
   const GAME_SECONDS = 20;
   const COUNTDOWN_STEP_MS = 1000;
   const GO_DISPLAY_MS = 250;
+  const READY_LABEL = "I'm ready — record locally";
   let stream = null;
   let landmarker = null;
   let runtimePromise = null;
@@ -41,7 +41,6 @@ if (app) {
   let running = false;
   let armed = false;
   let countdownActive = false;
-  let currentMode = 'casual';
   let endTime = 0;
   let score = 0;
   let lastZone = 0;
@@ -265,12 +264,12 @@ if (app) {
             }
           } else if (poseReady) {
             startButton.disabled = false;
-            startButton.textContent = "I'm ready";
+            startButton.textContent = READY_LABEL;
             setStatus('Pose detected — click I\'m ready, then take your position', 'ready');
           } else {
             // Readiness is a user decision; a pose is required to start, not to arm the run.
             startButton.disabled = false;
-            startButton.textContent = "I'm ready";
+            startButton.textContent = READY_LABEL;
             setStatus('Detector ready — click I\'m ready, then step into frame', 'ready');
           }
         }
@@ -298,7 +297,7 @@ if (app) {
       await initialisePoseRuntime();
       enableButton.hidden = true;
       startButton.disabled = false;
-      startButton.textContent = "I'm ready";
+      startButton.textContent = READY_LABEL;
       detectorLoop = requestAnimationFrame(detectFrame);
     } catch (error) {
       enableButton.disabled = false;
@@ -359,13 +358,11 @@ if (app) {
 
   function armRun() {
     if (!landmarker || running || countdownActive || armed) return;
-    currentMode = document.querySelector('input[name="mode"]:checked').value;
     showError('');
     resultCard.hidden = true;
     resetButton.hidden = true;
     startButton.disabled = true;
     startButton.textContent = 'Waiting for your pose…';
-    modeInputs.forEach((input) => { input.disabled = true; });
     score = 0;
     lastZone = 0;
     lastCountAt = 0;
@@ -382,17 +379,14 @@ if (app) {
     countdownActive = true;
     setStatus('Pose locked — countdown commencing', 'ready');
 
-    if (currentMode === 'hof') {
-      try {
-        startRecording();
-      } catch (error) {
-        showError(error.message);
-        countdownActive = false;
-        modeInputs.forEach((input) => { input.disabled = false; });
-        startButton.disabled = false;
-        startButton.textContent = "I'm ready";
-        return;
-      }
+    try {
+      startRecording();
+    } catch (error) {
+      showError(error.message);
+      countdownActive = false;
+      startButton.disabled = false;
+      startButton.textContent = READY_LABEL;
+      return;
     }
 
     for (const value of ['3', '2', '1']) {
@@ -415,7 +409,7 @@ if (app) {
     cancelAnimationFrame(gameLoop);
     timeEl.textContent = '0.0';
     setStatus('Run complete — detector remains local', 'ready');
-    const blob = currentMode === 'hof' ? await stopRecording() : null;
+    const blob = await stopRecording();
 
     resultScore.textContent = score;
     resultCopy.textContent = score === 67
@@ -426,7 +420,7 @@ if (app) {
     shareText.value = shareableResult();
     copyShareStatus.textContent = '';
     resultCard.hidden = false;
-    recordingReview.hidden = currentMode !== 'hof';
+    recordingReview.hidden = false;
     if (blob) {
       if (recordingUrl) URL.revokeObjectURL(recordingUrl);
       recordingUrl = URL.createObjectURL(blob);
@@ -462,9 +456,8 @@ if (app) {
     shareText.value = '';
     copyShareStatus.textContent = '';
     resetButton.hidden = true;
-    modeInputs.forEach((input) => { input.disabled = false; });
     startButton.disabled = !landmarker;
-    startButton.textContent = landmarker ? "I'm ready" : 'Detector is still loading…';
+    startButton.textContent = landmarker ? READY_LABEL : 'Detector is still loading…';
     showError('');
   }
 
@@ -505,13 +498,6 @@ if (app) {
     }
   }
 
-  modeInputs.forEach((input) => {
-    input.addEventListener('change', () => {
-      document.querySelectorAll('.mode-option').forEach((label) => {
-        label.classList.toggle('active', label.contains(document.querySelector('input[name="mode"]:checked')));
-      });
-    });
-  });
   preloadPoseRuntime();
   enableButton.addEventListener('click', initialiseDetector);
   startButton.addEventListener('click', armRun);

--- a/brainrot/templates/brainrot/counter.html
+++ b/brainrot/templates/brainrot/counter.html
@@ -6,7 +6,7 @@
 {% block content %}
 <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
 <link rel="preconnect" href="https://storage.googleapis.com" crossorigin>
-<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260814.4">
+<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260814.5">
 {% if turnstile_enabled %}<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>{% endif %}
 
 <main class="br-page counter-page" id="counter-app"
@@ -27,8 +27,8 @@
   </section>
 
   <section class="privacy-strip" aria-label="Camera privacy information">
-    <strong>Camera privacy:</strong> pose detection runs in this browser. Casual runs are never recorded or uploaded.
-    Hall of Fame runs are recorded locally and upload only after you press submit.
+    <strong>Camera privacy:</strong> pose detection and recording run in this browser. Every run is recorded locally
+    from the countdown, but nothing uploads unless you press Submit to Hall of Fame. Resetting or closing discards it.
   </section>
 
   <section class="counter-layout">
@@ -56,20 +56,9 @@
       </div>
       <div class="timer-block"><span>time remaining</span><strong id="counter-time">20.0</strong></div>
 
-      <fieldset class="run-mode" id="run-mode">
-        <legend>Run classification</legend>
-        <label class="mode-option active">
-          <input type="radio" name="mode" value="casual" checked>
-          <span><strong>Casual Run</strong><small>No recording. The score lives and dies in this tab.</small></span>
-        </label>
-        <label class="mode-option">
-          <input type="radio" name="mode" value="hof">
-          <span><strong>Hall of Fame Run</strong><small>Record locally now; decide whether to upload after.</small></span>
-        </label>
-      </fieldset>
-
       <button class="br-primary" id="enable-camera">Enable camera</button>
       <button class="br-primary" id="start-run" disabled>Detector is still loading…</button>
+      <p class="subtle run-consent">I'm ready starts a local recording. Submitting remains your decision.</p>
       <button class="br-secondary" id="reset-run" hidden>Run this foolish experiment again</button>
       <p class="counter-error" id="counter-error" role="alert"></p>
     </aside>
@@ -105,5 +94,5 @@
 </main>
 
 {# Keep this version in step with counter.js so browsers cannot retain a broken runtime URL. #}
-<script type="module" src="{% static 'brainrot/counter.js' %}?v=20260814.8"></script>
+<script type="module" src="{% static 'brainrot/counter.js' %}?v=20260814.9"></script>
 {% endblock %}

--- a/brainrot/tests.py
+++ b/brainrot/tests.py
@@ -24,11 +24,14 @@ class BrainrotPageTests(TestCase):
 
     def test_counter_uses_cache_busted_runtime_and_has_share_box(self):
         response = self.client.get('/67/counter/')
-        self.assertContains(response, 'brainrot.css?v=20260814.4')
-        self.assertContains(response, 'counter.js?v=20260814.8')
+        self.assertContains(response, 'brainrot.css?v=20260814.5')
+        self.assertContains(response, 'counter.js?v=20260814.9')
         self.assertContains(response, 'id="counter-share-text"')
         self.assertContains(response, 'id="copy-counter-share"')
         self.assertContains(response, 'id="download-recording"')
+        self.assertNotContains(response, 'Run classification')
+        self.assertNotContains(response, 'Casual Run')
+        self.assertContains(response, 'nothing uploads unless you press Submit to Hall of Fame')
 
         script_path = finders.find('brainrot/counter.js')
         self.assertIsNotNone(script_path)
@@ -41,6 +44,9 @@ class BrainrotPageTests(TestCase):
         self.assertIn('preloadPoseRuntime();', script)
         self.assertLess(script.index('preloadPoseRuntime();'), script.index("enableButton.addEventListener('click'"))
         self.assertIn('return [11, 12, 15, 16].every', script)
+        self.assertNotIn('currentMode', script)
+        self.assertNotIn('modeInputs', script)
+        self.assertIn('const blob = await stopRecording();', script)
 
 
 class VideoValidationTests(TestCase):


### PR DESCRIPTION
## Summary

- remove the separate Casual Run and Hall of Fame Run selection
- record every run locally from the 3–2–1 countdown through the end of the 20-second timer
- show the same post-run recording preview, download, discard, and optional Hall submission controls after every run
- keep upload as a separate explicit user action; resetting or closing discards the local Blob
- make the privacy notice and readiness label explicitly disclose local recording
- remove the redundant frontend mode state and bump static asset versions
- add regression coverage ensuring the old mode UI/state cannot return

## Privacy behaviour

Opening the page preloads the pose runtime but does not access the camera. `Enable camera` requests access. `I'm ready — record locally` starts a local MediaRecorder when the pose locks and countdown begins. No video is uploaded unless the user later presses `Submit to Hall of Fame`.

## Verification

- `node --check brainrot/static/brainrot/counter.js`
- `python manage.py check`
- `python manage.py makemigrations --check --dry-run`
- `python manage.py test brainrot oj` (9 tests passed)

No migration or dependency is required. Run `python manage.py collectstatic --noinput` after merging.
