### PR TITLE
Fix MediaRecorder duration validation

### DIFF
--- a/brainrot/tests.py
+++ b/brainrot/tests.py
@@ -9,7 +9,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase, override_settings
 
 from .models import HallOfFameEntry
-from .validators import ValidatedVideo, _packet_duration
+from .validators import ValidatedVideo, _packet_duration, _probe_video
 
 
 class BrainrotPageTests(TestCase):
@@ -57,6 +57,25 @@ class VideoValidationTests(TestCase):
             stdout='87.000000,0.033333\n109.966667,0.033333\n',
         )
         self.assertAlmostEqual(_packet_duration('/tmp/run.webm', '/usr/bin/ffprobe'), 23.0)
+
+    @override_settings(HOF_MAX_VIDEO_SECONDS=26)
+    @patch('brainrot.validators.shutil.which', return_value='/usr/bin/ffprobe')
+    @patch('brainrot.validators._packet_duration', return_value=23.0)
+    @patch('brainrot.validators.subprocess.run')
+    def test_probe_prefers_packet_span_over_incorrect_container_duration(
+        self,
+        run,
+        packet_duration,
+        which,
+    ):
+        run.return_value = SimpleNamespace(
+            returncode=0,
+            stdout='{"streams":[{"codec_type":"video","codec_name":"vp8"}],"format":{"duration":"110.0"}}',
+        )
+        upload = SimpleUploadedFile('run.webm', b'video bytes', content_type='video/webm')
+
+        self.assertEqual(_probe_video(upload, 'video/webm'), 23.0)
+        packet_duration.assert_called_once()
 
     def test_typing_result_has_share_box_and_url(self):
         response = self.client.get('/67/typing/')

--- a/brainrot/validators.py
+++ b/brainrot/validators.py
@@ -103,11 +103,16 @@ def _probe_video(upload, expected_mime):
         if not any(stream.get('codec_name') in allowed_codecs for stream in video_streams):
             raise ValidationError('The video codec is not supported.')
         try:
-            duration = float(payload.get('format', {}).get('duration', 0))
+            container_duration = float(payload.get('format', {}).get('duration', 0))
         except (TypeError, ValueError):
-            duration = 0
-        if duration <= 0:
-            duration = _packet_duration(path, ffprobe)
+            container_duration = 0
+
+        # MediaRecorder may write a non-zero container duration based on the
+        # lifetime of the camera track rather than this recording. Packet PTS
+        # span reflects the actual encoded evidence and is therefore preferred
+        # whenever ffprobe can recover it.
+        packet_duration = _packet_duration(path, ffprobe)
+        duration = packet_duration if packet_duration > 1 else container_duration
         if duration <= 1 or duration > settings.HOF_MAX_VIDEO_SECONDS:
             raise ValidationError(
                 f'Video duration must be between 1 and {settings.HOF_MAX_VIDEO_SECONDS:g} seconds.'


### PR DESCRIPTION
## Summary
- always measure the encoded video packet timestamp span with `ffprobe`
- prefer that packet span over misleading non-zero WebM container duration metadata
- retain the container duration as a fallback when packet timestamps cannot be recovered
- add a regression test for a 23-second recording whose container reports 110 seconds

## Validation
- `python3 manage.py check`
- `python3 manage.py makemigrations --check --dry-run`
- `python3 manage.py test brainrot oj` (10 tests passed)
- `git diff --check`

No migrations or dependency changes.