### PR TITLE
Handle missing WebM packet durations

### DIFF
--- a/brainrot/tests.py
+++ b/brainrot/tests.py
@@ -5,6 +5,7 @@ from unittest.mock import patch
 
 from django.contrib.auth import get_user_model
 from django.contrib.staticfiles import finders
+from django.core.exceptions import ValidationError
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase, override_settings
 
@@ -57,6 +58,31 @@ class VideoValidationTests(TestCase):
             stdout='87.000000,0.033333\n109.966667,0.033333\n',
         )
         self.assertAlmostEqual(_packet_duration('/tmp/run.webm', '/usr/bin/ffprobe'), 23.0)
+
+    @patch('brainrot.validators.subprocess.run')
+    def test_packet_duration_keeps_pts_when_packet_duration_is_na(self, run):
+        run.return_value = SimpleNamespace(
+            returncode=0,
+            stdout='87.000000,N/A\n109.966667,N/A\n',
+        )
+        self.assertAlmostEqual(
+            _packet_duration('/tmp/firefox-run.webm', '/usr/bin/ffprobe'),
+            22.966667,
+        )
+
+    @override_settings(HOF_MAX_VIDEO_SECONDS=26)
+    @patch('brainrot.validators.shutil.which', return_value='/usr/bin/ffprobe')
+    @patch('brainrot.validators._packet_duration', return_value=0)
+    @patch('brainrot.validators.subprocess.run')
+    def test_invalid_duration_error_reports_detected_value(self, run, packet_duration, which):
+        run.return_value = SimpleNamespace(
+            returncode=0,
+            stdout='{"streams":[{"codec_type":"video","codec_name":"vp8"}],"format":{"duration":"110.0"}}',
+        )
+        upload = SimpleUploadedFile('run.webm', b'video bytes', content_type='video/webm')
+
+        with self.assertRaisesMessage(ValidationError, 'detected as 110.00 seconds'):
+            _probe_video(upload, 'video/webm')
 
     @override_settings(HOF_MAX_VIDEO_SECONDS=26)
     @patch('brainrot.validators.shutil.which', return_value='/usr/bin/ffprobe')

--- a/brainrot/validators.py
+++ b/brainrot/validators.py
@@ -37,12 +37,17 @@ def _packet_duration(path, ffprobe):
         values = line.split(',')
         try:
             pts = float(values[0])
-            packet_duration = float(values[1]) if len(values) > 1 and values[1] else 0
-            first_pts = pts if first_pts is None else min(first_pts, pts)
-            packet_end = pts + packet_duration
-            end_time = packet_end if end_time is None else max(end_time, packet_end)
-        except ValueError:
+        except (IndexError, ValueError):
             continue
+        try:
+            packet_duration = float(values[1]) if len(values) > 1 and values[1] else 0
+        except ValueError:
+            # Firefox WebM commonly reports a valid PTS with duration_time=N/A.
+            # The PTS still contributes to the encoded packet span.
+            packet_duration = 0
+        first_pts = pts if first_pts is None else min(first_pts, pts)
+        packet_end = pts + max(0, packet_duration)
+        end_time = packet_end if end_time is None else max(end_time, packet_end)
     if first_pts is None or end_time is None:
         return 0
     # MediaRecorder packets may retain timestamps from the long-lived camera
@@ -115,7 +120,8 @@ def _probe_video(upload, expected_mime):
         duration = packet_duration if packet_duration > 1 else container_duration
         if duration <= 1 or duration > settings.HOF_MAX_VIDEO_SECONDS:
             raise ValidationError(
-                f'Video duration must be between 1 and {settings.HOF_MAX_VIDEO_SECONDS:g} seconds.'
+                f'Video duration was detected as {duration:.2f} seconds; it must be between '
+                f'1 and {settings.HOF_MAX_VIDEO_SECONDS:g} seconds.'
             )
         return duration
     except (json.JSONDecodeError, ValueError, subprocess.TimeoutExpired):


### PR DESCRIPTION
## Root cause
Firefox/MediaRecorder WebM packets can have a valid `pts_time` while `duration_time` is `N/A`. The validator attempted to parse both fields in one `try` block, so it discarded the entire packet—including its valid timestamp. With every packet discarded, validation fell back to the misleading container duration and rejected an actual ~23-second recording.

## Changes
- retain valid packet timestamps when packet duration is absent or non-numeric
- treat unknown per-packet duration as zero while still measuring the first-to-last PTS span
- include the detected duration in validation errors for useful field diagnostics
- add regression coverage for `duration_time=N/A` and the diagnostic message

## Validation
- `SECRET_KEY=test-only-key python manage.py test brainrot oj` — 12 tests passed
- `python manage.py check` — passed
- `python manage.py makemigrations --check --dry-run` — no changes
- `python -m py_compile brainrot/validators.py brainrot/tests.py`
- `git diff --check`

No migration, dependency, frontend, or static-file changes.