### PR TITLE
Add browser-local C++ 67ifier

### DIFF
--- a/brainrot/js_tests/cpp_67ifier_core.test.mjs
+++ b/brainrot/js_tests/cpp_67ifier_core.test.mjs
@@ -1,0 +1,69 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {tokenizeCpp, transformCpp} from '../static/brainrot/cpp_67ifier_core.mjs';
+
+test('preserves comments, quoted literals, raw strings, and preprocessor directives', () => {
+  const source = `#define LIMIT 67
+// value should stay 67 here
+const char* label = "value 67";
+auto raw = R"tag(value 67)tag";
+int value = LIMIT;`;
+  const result = transformCpp(source, {numericMode: 'common'});
+
+  assert.match(result.code, /^#define LIMIT 67/m);
+  assert.match(result.code, /\/\/ value should stay 67 here/);
+  assert.match(result.code, /"value 67"/);
+  assert.match(result.code, /R"tag\(value 67\)tag"/);
+  assert.match(result.code, /LIMIT/);
+  assert.equal(result.mapping.value, 'sixone');
+});
+
+test('renames user identifiers consistently and preserves common C++ names', () => {
+  const source = 'int main(){ std::vector<int> values; values.push_back(6); return values.size(); }';
+  const result = transformCpp(source, {numericMode: 'off'});
+
+  assert.equal(result.mapping.values, 'sixseven');
+  assert.equal(result.code.match(/sixseven/g).length, 3);
+  assert.match(result.code, /int main\(\)/);
+  assert.match(result.code, /std::vector/);
+  assert.match(result.code, /push_back/);
+});
+
+test('honours the preserve list and conservatively keeps underscore names', () => {
+  const source = 'int solve(int grader_value, int _abi_name) { return grader_value + _abi_name; }';
+  const result = transformCpp(source, {
+    numericMode: 'off',
+    preservedNames: 'solve, grader_value',
+  });
+
+  assert.equal(result.code, source);
+  assert.deepEqual(result.mapping, {});
+});
+
+test('common mode changes themed integer specimens but not floating point', () => {
+  const source = 'auto a=0; auto b=67ULL; auto c=3.14;';
+  const result = transformCpp(source, {renameIdentifiers: false, numericMode: 'common'});
+
+  assert.match(result.code, /\(67 \^ 67\)/);
+  assert.match(result.code, /\(61ULL \+ 6ULL\)/);
+  assert.match(result.code, /3\.14/);
+  assert.equal(result.stats.transformedIntegers, 2);
+});
+
+test('full mode rewrites arbitrary supported integers with logarithmic Horner expressions', () => {
+  const result = transformCpp('int answer = 42;', {renameIdentifiers: false, numericMode: 'all'});
+
+  assert.doesNotMatch(result.code, /\b42\b/);
+  assert.match(result.code, /7 - 6/);
+  assert.match(result.code, /int answer = \(/);
+  assert.equal(result.stats.transformedIntegers, 1);
+});
+
+test('tokenizer does not split prefixed and raw literals', () => {
+  const literalTokens = tokenizeCpp('auto a=u8"67"; auto b=LR"x(61)x";')
+    .filter((token) => token.type === 'literal')
+    .map((token) => token.text);
+
+  assert.deepEqual(literalTokens, ['u8"67"', 'LR"x(61)x"']);
+});

--- a/brainrot/static/brainrot/brainrot.css
+++ b/brainrot/static/brainrot/brainrot.css
@@ -71,6 +71,8 @@
 .br-game-card p { max-width: 390px; color: #334155; }
 .br-counter-card { background: var(--br-lime); }
 .br-typing-card { background: var(--br-blue); }
+.br-code-card { grid-column: 1 / -1; min-height: 280px; background: #ffd6a0; }
+.br-code-card .br-card-number { right: 1rem; bottom: -1.4rem; font-size: clamp(6rem, 16vw, 12rem); }
 .br-card-number {
   position: absolute;
   right: -1rem;
@@ -267,8 +269,38 @@
 .hall-share-card > p { color: var(--br-muted); }
 .hall-share-card textarea { width: 100%; padding: .8rem; resize: vertical; border: 1px solid var(--br-line); border-radius: 10px; background: #f8fafc; font: .85rem/1.5 ui-monospace, SFMono-Regular, Consolas, monospace; }
 
+.cpp67-heading { max-width: 960px; margin: 4.5rem 0 2rem; }
+.cpp67-heading h1 { margin: .35rem 0 1rem; font-size: clamp(3.5rem, 10vw, 8rem); font-weight: 950; line-height: .88; letter-spacing: -.07em; }
+.cpp67-heading p { max-width: 760px; color: var(--br-muted); font-size: clamp(1rem, 2vw, 1.25rem); }
+.cpp67-options { display: grid; grid-template-columns: 1fr 1fr 1.5fr; gap: .8rem; margin: 1.2rem 0; }
+.cpp67-options > label { display: flex; flex-direction: column; justify-content: center; gap: .45rem; min-height: 78px; padding: .8rem 1rem; border: 1px solid var(--br-line); border-radius: 14px; background: rgba(255,255,255,.92); }
+.cpp67-options > label > span { color: var(--br-muted); font-size: .72rem; font-weight: 800; letter-spacing: .05em; text-transform: uppercase; }
+.cpp67-options select, .cpp67-options input[type="text"] { width: 100%; padding: .55rem .65rem; border: 1px solid #cbd5e1; border-radius: 8px; background: white; color: var(--br-ink); }
+.cpp67-options .cpp67-toggle { flex-direction: row; align-items: center; justify-content: flex-start; gap: .7rem; cursor: pointer; }
+.cpp67-toggle input { width: 1.1rem; height: 1.1rem; accent-color: var(--br-accent-dark); }
+.cpp67-toggle span { display: flex; flex-direction: column; color: var(--br-ink) !important; font-size: .82rem !important; letter-spacing: 0 !important; text-transform: none !important; }
+.cpp67-toggle small { margin-top: .15rem; color: var(--br-muted); font-weight: 500; }
+.cpp67-workbench { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; }
+.cpp67-editor-card { overflow: hidden; border: 1px solid var(--br-line); border-radius: 18px; background: #111827; box-shadow: 0 12px 35px rgba(15,23,42,.1); }
+.cpp67-editor-card header { display: flex; justify-content: space-between; padding: .75rem 1rem; border-bottom: 1px solid #334155; color: #e2e8f0; font-size: .82rem; }
+.cpp67-editor-card header span { color: #94a3b8; text-transform: uppercase; letter-spacing: .08em; }
+.cpp67-editor-card textarea { display: block; width: 100%; min-height: 510px; padding: 1.1rem; resize: vertical; border: 0; outline: 0; background: #111827; color: #e2e8f0; tab-size: 4; font: .88rem/1.55 ui-monospace, SFMono-Regular, Consolas, monospace; }
+.cpp67-output-card textarea { background: #172033; color: #d8ff62; }
+.cpp67-actions { display: flex; flex-wrap: wrap; align-items: center; gap: .65rem; margin: 1rem 0; }
+.cpp67-actions .br-primary, .cpp67-actions .br-secondary { width: auto; min-width: 145px; margin: 0; }
+.cpp67-actions .br-text-button { display: inline-block; margin: 0 .2rem; }
+.cpp67-report { display: grid; grid-template-columns: repeat(3, minmax(120px, 190px)) 1fr; gap: .7rem; align-items: stretch; margin-top: 1rem; }
+.cpp67-report > div, .cpp67-report > p { margin: 0; padding: .9rem 1rem; border: 1px solid var(--br-line); border-radius: 12px; background: rgba(255,255,255,.9); }
+.cpp67-report > div { display: flex; flex-direction: column; }
+.cpp67-report span { color: var(--br-muted); font-size: .67rem; font-weight: 800; letter-spacing: .05em; text-transform: uppercase; }
+.cpp67-report strong { font-size: 1.45rem; }
+.cpp67-report p { color: var(--br-muted); font-size: .82rem; line-height: 1.5; }
+.cpp67-notes { margin: 1.2rem 0; padding: 1rem 1.2rem; border: 1px dashed #94a3b8; border-radius: 12px; color: var(--br-muted); font-size: .85rem; }
+.cpp67-notes summary { color: var(--br-ink); font-weight: 800; cursor: pointer; }
+.cpp67-notes p { max-width: 900px; margin-bottom: 0; }
+
 @media (max-width: 780px) {
-  .br-game-grid, .counter-layout, .result-card, .hall-detail-grid { grid-template-columns: 1fr; }
+  .br-game-grid, .counter-layout, .result-card, .hall-detail-grid, .cpp67-workbench, .cpp67-options { grid-template-columns: 1fr; }
   .duel-grid { grid-template-columns: 1fr; }
   .br-game-card { min-height: 300px; }
   .br-toolbar span { display: none; }
@@ -278,6 +310,16 @@
   .hall-detail-heading { align-items: start; flex-direction: column; gap: .6rem; }
   .hall-detail-heading .br-kicker { position: static; transform: none; }
   .typing-viewport { height: 205px; padding: 1.3rem; }
+  .cpp67-heading { margin-top: 3rem; }
+  .cpp67-editor-card textarea { min-height: 360px; }
+  .cpp67-report { grid-template-columns: repeat(3, 1fr); }
+  .cpp67-report p { grid-column: 1 / -1; }
+}
+
+@media (max-width: 520px) {
+  .cpp67-report { grid-template-columns: 1fr; }
+  .cpp67-report p { grid-column: auto; }
+  .cpp67-actions .br-primary, .cpp67-actions .br-secondary { width: 100%; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/brainrot/static/brainrot/cpp_67ifier.js
+++ b/brainrot/static/brainrot/cpp_67ifier.js
@@ -1,0 +1,95 @@
+import {transformCpp} from './cpp_67ifier_core.mjs?v=20260814.1';
+
+const input = document.getElementById('cpp67-input');
+const output = document.getElementById('cpp67-output');
+const rename = document.getElementById('cpp67-rename');
+const numberMode = document.getElementById('cpp67-number-mode');
+const preserve = document.getElementById('cpp67-preserve');
+const transformButton = document.getElementById('cpp67-transform');
+const copyButton = document.getElementById('cpp67-copy');
+const downloadButton = document.getElementById('cpp67-download');
+const sampleButton = document.getElementById('cpp67-sample');
+const resetButton = document.getElementById('cpp67-reset');
+const nameCount = document.getElementById('cpp67-name-count');
+const integerCount = document.getElementById('cpp67-integer-count');
+const expansion = document.getElementById('cpp67-expansion');
+const status = document.getElementById('cpp67-status');
+
+const sample = `#include <bits/stdc++.h>
+using namespace std;
+
+// The string and this comment must remain exactly as written.
+long long solve(vector<int> values) {
+    long long answer = 0;
+    for (int index = 0; index < (int)values.size(); ++index) {
+        if (values[index] == 67) answer += values[index] * 6;
+    }
+    cout << "SIX SEVEN: " << answer << '\\n';
+    return answer + 61;
+}
+
+int main() {
+    vector<int> data = {6, 7, 61, 67};
+    cout << solve(data) << '\\n';
+}`;
+
+function renderResult(result) {
+  output.value = result.code;
+  nameCount.textContent = result.stats.renamedIdentifiers;
+  integerCount.textContent = result.stats.transformedIntegers;
+  expansion.textContent = `${result.stats.expansionPercent}%`;
+  status.textContent = result.warnings.length
+    ? result.warnings.join(' ')
+    : 'Transformation complete. The Institute found no paperwork to add.';
+}
+
+function transform() {
+  renderResult(transformCpp(input.value, {
+    renameIdentifiers: rename.checked,
+    numericMode: numberMode.value,
+    preservedNames: preserve.value,
+  }));
+}
+
+async function copyOutput() {
+  if (!output.value) transform();
+  try {
+    await navigator.clipboard.writeText(output.value);
+  } catch {
+    output.focus();
+    output.select();
+    document.execCommand('copy');
+  }
+  status.textContent = 'Peer-reviewed source copied to clipboard.';
+}
+
+function downloadOutput() {
+  if (!output.value) transform();
+  const url = URL.createObjectURL(new Blob([output.value], {type: 'text/x-c++src;charset=utf-8'}));
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = 'six-seven.cpp';
+  link.click();
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+  status.textContent = 'six-seven.cpp has escaped the laboratory.';
+}
+
+transformButton.addEventListener('click', transform);
+copyButton.addEventListener('click', copyOutput);
+downloadButton.addEventListener('click', downloadOutput);
+sampleButton.addEventListener('click', () => {
+  input.value = sample;
+  transform();
+});
+resetButton.addEventListener('click', () => {
+  input.value = '';
+  output.value = '';
+  nameCount.textContent = '0';
+  integerCount.textContent = '0';
+  expansion.textContent = '100%';
+  status.textContent = 'Awaiting a scientifically unnecessary program.';
+  input.focus();
+});
+
+input.value = sample;
+transform();

--- a/brainrot/static/brainrot/cpp_67ifier_core.mjs
+++ b/brainrot/static/brainrot/cpp_67ifier_core.mjs
@@ -1,0 +1,353 @@
+const CPP_KEYWORDS = new Set(`
+alignas alignof and and_eq asm atomic_cancel atomic_commit atomic_noexcept auto
+bitand bitor bool break case catch char char8_t char16_t char32_t class compl
+concept const consteval constexpr constinit const_cast continue co_await co_return
+co_yield decltype default delete do double dynamic_cast else enum explicit export
+extern false float for friend goto if inline int long mutable namespace new noexcept
+not not_eq nullptr operator or or_eq private protected public reflexpr register
+reinterpret_cast requires return short signed sizeof static static_assert static_cast
+struct switch synchronized template this thread_local throw true try typedef typeid
+typename union unsigned using virtual void volatile wchar_t while xor xor_eq
+`.trim().split(/\s+/));
+
+const COMMON_CPP_NAMES = new Set(`
+main std vector string wstring u8string array map multimap unordered_map set multiset
+unordered_set queue deque stack priority_queue pair tuple optional variant any span
+cin cout cerr clog endl flush fixed scientific setprecision ios istream ostream
+ifstream ofstream stringstream istringstream ostringstream
+sort stable_sort reverse rotate lower_bound upper_bound equal_range binary_search
+min max min_element max_element swap gcd lcm iota accumulate inner_product partial_sum
+fill fill_n copy copy_if move transform replace remove remove_if unique partition
+find find_if count count_if all_of any_of none_of for_each distance next prev begin end
+rbegin rend size ssize empty data
+push_back emplace_back pop_back push_front emplace_front pop_front push emplace pop top
+front back insert erase clear reserve resize capacity shrink_to_fit at first second
+make_pair make_tuple tie get make_shared make_unique shared_ptr unique_ptr weak_ptr
+numeric_limits function less greater hash move forward declval
+abs labs llabs sqrt cbrt pow log log2 log10 exp ceil floor round trunc hypot
+memset memcpy memmove strcmp strlen scanf printf puts putchar getchar
+sync_with_stdio freopen stdin stdout NULL EOF INT_MAX INT_MIN UINT_MAX LLONG_MAX LLONG_MIN
+M_PI size_t ptrdiff_t int8_t int16_t int32_t int64_t uint8_t uint16_t uint32_t uint64_t
+exception runtime_error logic_error invalid_argument out_of_range assert
+`.trim().split(/\s+/));
+
+const NAME_PARTS = ['sixseven', 'sixtyseven', 'sixone', 'sixtyone'];
+const INTEGER_SUFFIX = /(?:[uU](?:ll|LL|l|L)?|(?:ll|LL|l|L)[uU]?)?$/;
+
+function isIdentifierStart(character) {
+  return /[A-Za-z_]/.test(character || '');
+}
+
+function isIdentifierPart(character) {
+  return /[A-Za-z0-9_]/.test(character || '');
+}
+
+function consumeQuoted(source, start, quoteIndex) {
+  const quote = source[quoteIndex];
+  let index = quoteIndex + 1;
+  while (index < source.length) {
+    if (source[index] === '\\') {
+      index += 2;
+      continue;
+    }
+    index += 1;
+    if (source[index - 1] === quote) break;
+  }
+  return source.slice(start, index);
+}
+
+function consumeRawString(source, start, rawMarkerIndex) {
+  const delimiterStart = rawMarkerIndex + 2;
+  const openingParen = source.indexOf('(', delimiterStart);
+  if (openingParen === -1 || openingParen - delimiterStart > 16) {
+    return consumeQuoted(source, start, rawMarkerIndex + 1);
+  }
+  const delimiter = source.slice(delimiterStart, openingParen);
+  if (/[\s\\()]/.test(delimiter)) {
+    return consumeQuoted(source, start, rawMarkerIndex + 1);
+  }
+  const closing = `)${delimiter}\"`;
+  const closingIndex = source.indexOf(closing, openingParen + 1);
+  const end = closingIndex === -1 ? source.length : closingIndex + closing.length;
+  return source.slice(start, end);
+}
+
+function literalAt(source, index) {
+  const rest = source.slice(index);
+  const raw = rest.match(/^(?:u8|u|U|L)?R\"/);
+  if (raw) {
+    const marker = index + raw[0].length - 2;
+    return consumeRawString(source, index, marker);
+  }
+  const quoted = rest.match(/^(?:u8|u|U|L)?([\"'])/);
+  if (quoted) {
+    const quoteIndex = index + quoted[0].length - 1;
+    return consumeQuoted(source, index, quoteIndex);
+  }
+  return null;
+}
+
+function consumeNumber(source, start) {
+  let index = start;
+  let previous = '';
+  while (index < source.length) {
+    const character = source[index];
+    if (/[A-Za-z0-9_'.]/.test(character)) {
+      previous = character;
+      index += 1;
+      continue;
+    }
+    if ((character === '+' || character === '-') && /[eEpP]/.test(previous)) {
+      previous = character;
+      index += 1;
+      continue;
+    }
+    break;
+  }
+  return source.slice(start, index);
+}
+
+function consumePreprocessorLine(source, start) {
+  let index = start;
+  while (index < source.length) {
+    const newline = source.indexOf('\n', index);
+    if (newline === -1) return source.slice(start);
+    let check = newline - 1;
+    if (check >= start && source[check] === '\r') check -= 1;
+    let backslashes = 0;
+    while (check >= start && source[check] === '\\') {
+      backslashes += 1;
+      check -= 1;
+    }
+    index = newline + 1;
+    if (backslashes % 2 === 0) return source.slice(start, index);
+  }
+  return source.slice(start);
+}
+
+export function tokenizeCpp(source) {
+  const tokens = [];
+  let index = 0;
+  let lineOnlyWhitespace = true;
+
+  const push = (type, text) => {
+    tokens.push({type, text});
+    if (text.includes('\n')) {
+      lineOnlyWhitespace = /^[\t \r]*$/.test(text.slice(text.lastIndexOf('\n') + 1));
+    } else if (!/^[\t \r]*$/.test(text)) {
+      lineOnlyWhitespace = false;
+    }
+    index += text.length;
+  };
+
+  while (index < source.length) {
+    const character = source[index];
+    if (lineOnlyWhitespace && character === '#') {
+      push('preprocessor', consumePreprocessorLine(source, index));
+      continue;
+    }
+    if (/\s/.test(character)) {
+      const match = source.slice(index).match(/^\s+/)[0];
+      push('whitespace', match);
+      continue;
+    }
+    if (source.startsWith('//', index)) {
+      const newline = source.indexOf('\n', index);
+      push('comment', source.slice(index, newline === -1 ? source.length : newline));
+      continue;
+    }
+    if (source.startsWith('/*', index)) {
+      const closing = source.indexOf('*/', index + 2);
+      push('comment', source.slice(index, closing === -1 ? source.length : closing + 2));
+      continue;
+    }
+    const literal = literalAt(source, index);
+    if (literal) {
+      push('literal', literal);
+      continue;
+    }
+    if (/[0-9]/.test(character) || (character === '.' && /[0-9]/.test(source[index + 1] || ''))) {
+      push('number', consumeNumber(source, index));
+      continue;
+    }
+    if (isIdentifierStart(character)) {
+      let end = index + 1;
+      while (isIdentifierPart(source[end])) end += 1;
+      push('identifier', source.slice(index, end));
+      continue;
+    }
+    push('punctuation', character);
+  }
+  return tokens;
+}
+
+function integerParts(text) {
+  if (text.includes('_')) return null;
+  const suffixMatch = text.match(INTEGER_SUFFIX);
+  const suffix = suffixMatch ? suffixMatch[0] : '';
+  const body = text.slice(0, text.length - suffix.length).replaceAll("'", '');
+  let radix = 10;
+  let digits = body;
+  if (/^0[xX][0-9a-fA-F]+$/.test(body)) {
+    radix = 16;
+    digits = body.slice(2);
+  } else if (/^0[bB][01]+$/.test(body)) {
+    radix = 2;
+    digits = body.slice(2);
+  } else if (/^0[0-7]+$/.test(body) && body.length > 1) {
+    radix = 8;
+    digits = body.slice(1);
+  } else if (!/^(?:0|[1-9][0-9]*)$/.test(body)) {
+    return null;
+  }
+  try {
+    return {value: BigInt(parseBigIntDigits(digits || '0', radix)), suffix};
+  } catch {
+    return null;
+  }
+}
+
+function parseBigIntDigits(digits, radix) {
+  let value = 0n;
+  const base = BigInt(radix);
+  for (const digit of digits.toLowerCase()) {
+    const code = digit >= 'a' ? digit.charCodeAt(0) - 87 : Number(digit);
+    if (!Number.isInteger(code) || code < 0 || code >= radix) throw new Error('invalid digit');
+    value = value * base + BigInt(code);
+  }
+  return value;
+}
+
+function themedAtoms(suffix) {
+  const decorate = (value) => `${value}${suffix}`;
+  return {
+    zero: `(${decorate(67)} ^ ${decorate(67)})`,
+    one: `(${decorate(7)} - ${decorate(6)})`,
+    two: `((${decorate(7)} - ${decorate(6)}) + (${decorate(7)} - ${decorate(6)}))`,
+  };
+}
+
+function commonInteger(value, suffix) {
+  const number = value.toString();
+  const decorate = (item) => `${item}${suffix}`;
+  const atoms = themedAtoms(suffix);
+  const replacements = {
+    '0': atoms.zero,
+    '1': atoms.one,
+    '2': atoms.two,
+    '6': `(${decorate(67)} - ${decorate(61)})`,
+    '7': `(${decorate(6)} + ${atoms.one})`,
+    '61': `(${decorate(67)} - ${decorate(6)})`,
+    '67': `(${decorate(61)} + ${decorate(6)})`,
+  };
+  return replacements[number] || null;
+}
+
+function fullInteger(value, suffix) {
+  const atoms = themedAtoms(suffix);
+  if (value === 0n) return atoms.zero;
+  const bits = value.toString(2);
+  let expression = atoms.one;
+  for (const bit of bits.slice(1)) {
+    expression = `(${expression} * ${atoms.two}${bit === '1' ? ` + ${atoms.one}` : ''})`;
+  }
+  return expression;
+}
+
+function generatedName(sequence) {
+  let value = sequence;
+  const parts = [];
+  do {
+    parts.unshift(NAME_PARTS[value % NAME_PARTS.length]);
+    value = Math.floor(value / NAME_PARTS.length) - 1;
+  } while (value >= 0);
+  return parts.join('_');
+}
+
+function preprocessorIdentifiers(tokens) {
+  const names = new Set();
+  for (const token of tokens) {
+    if (token.type !== 'preprocessor') continue;
+    for (const match of token.text.matchAll(/[A-Za-z_][A-Za-z0-9_]*/g)) names.add(match[0]);
+  }
+  return names;
+}
+
+function parsePreservedNames(value) {
+  if (value instanceof Set) return new Set(value);
+  if (Array.isArray(value)) return new Set(value);
+  return new Set(String(value || '').split(/[\s,]+/).filter(Boolean));
+}
+
+export function transformCpp(source, options = {}) {
+  const numericMode = ['off', 'common', 'all'].includes(options.numericMode)
+    ? options.numericMode
+    : 'common';
+  const renameIdentifiers = options.renameIdentifiers !== false;
+  const tokens = tokenizeCpp(String(source));
+  const preserved = new Set([
+    ...CPP_KEYWORDS,
+    ...COMMON_CPP_NAMES,
+    ...preprocessorIdentifiers(tokens),
+    ...parsePreservedNames(options.preservedNames),
+  ]);
+  const sourceNames = new Set(tokens.filter((token) => token.type === 'identifier').map((token) => token.text));
+  const unavailableNames = new Set([...preserved, ...sourceNames]);
+  const mapping = new Map();
+  const warnings = new Set();
+  let sequence = 0;
+  let integerCount = 0;
+  let skippedNumberCount = 0;
+
+  const replacementName = (name) => {
+    if (!renameIdentifiers || preserved.has(name) || name.startsWith('_')) return name;
+    if (!mapping.has(name)) {
+      let candidate;
+      do {
+        candidate = generatedName(sequence);
+        sequence += 1;
+      } while (unavailableNames.has(candidate));
+      mapping.set(name, candidate);
+      unavailableNames.add(candidate);
+    }
+    return mapping.get(name);
+  };
+
+  const output = tokens.map((token) => {
+    if (token.type === 'identifier') return replacementName(token.text);
+    if (token.type !== 'number' || numericMode === 'off') return token.text;
+    const parsed = integerParts(token.text);
+    if (!parsed) {
+      skippedNumberCount += 1;
+      return token.text;
+    }
+    if (parsed.value.toString(2).length > 256) {
+      warnings.add('An integer wider than 256 bits was left unchanged to prevent a small output apocalypse.');
+      return token.text;
+    }
+    const transformed = numericMode === 'common'
+      ? commonInteger(parsed.value, parsed.suffix)
+      : fullInteger(parsed.value, parsed.suffix);
+    if (!transformed) return token.text;
+    integerCount += 1;
+    return transformed;
+  }).join('');
+
+  if (skippedNumberCount > 0 && numericMode !== 'off') {
+    warnings.add(`${skippedNumberCount} floating-point or user-defined numeric literal(s) were preserved.`);
+  }
+  if (renameIdentifiers && mapping.size > 0) {
+    warnings.add('External APIs, judge-required function names, and reflection may need the preserve list.');
+  }
+
+  return {
+    code: output,
+    mapping: Object.fromEntries(mapping),
+    stats: {
+      renamedIdentifiers: mapping.size,
+      transformedIntegers: integerCount,
+      expansionPercent: source.length ? Math.round((output.length / source.length) * 100) : 100,
+    },
+    warnings: [...warnings],
+  };
+}

--- a/brainrot/templates/brainrot/cpp_67ifier.html
+++ b/brainrot/templates/brainrot/cpp_67ifier.html
@@ -1,0 +1,79 @@
+{% extends 'base.html' %}
+{% load static %}
+
+{% block title %}C++ 67ifier{% endblock %}
+
+{% block content %}
+<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260814.7">
+<main class="br-page cpp67-page" id="cpp67-app">
+  <header class="br-toolbar">
+    <a href="{% url 'brainrot:index' %}">← Research division</a>
+    <span>No code is uploaded, compiled, judged, or understood by the server.</span>
+  </header>
+
+  <section class="cpp67-heading">
+    <span class="br-kicker">POST-LEGIBILITY SOFTWARE ENGINEERING</span>
+    <h1>C++ 67ifier</h1>
+    <p>A lightweight lexical instrument for making valid-looking C++ considerably more six-seven.</p>
+  </section>
+
+  <section class="privacy-strip">
+    <strong>Local laboratory:</strong> transformation happens entirely in this browser. Comments,
+    strings, raw strings, character literals, and preprocessor directives are preserved.
+  </section>
+
+  <section class="cpp67-options" aria-label="Transformation options">
+    <label class="cpp67-toggle">
+      <input id="cpp67-rename" type="checkbox" checked>
+      <span><strong>Rename user identifiers</strong><small>Known C++ / standard-library names stay sober.</small></span>
+    </label>
+    <label>
+      <span>Integer treatment</span>
+      <select id="cpp67-number-mode">
+        <option value="common">Common specimens only</option>
+        <option value="all">Full binary evil mode</option>
+        <option value="off">Leave numbers alone</option>
+      </select>
+    </label>
+    <label class="cpp67-preserve-label">
+      <span>Preserve these identifiers</span>
+      <input id="cpp67-preserve" type="text" placeholder="solve, interactive_api, graderFunction">
+    </label>
+  </section>
+
+  <section class="cpp67-workbench">
+    <article class="cpp67-editor-card">
+      <header><strong>Original C++</strong><span>input</span></header>
+      <textarea id="cpp67-input" spellcheck="false" aria-label="Original C++ source"></textarea>
+    </article>
+    <article class="cpp67-editor-card cpp67-output-card">
+      <header><strong>Peer-reviewed C++</strong><span>output</span></header>
+      <textarea id="cpp67-output" spellcheck="false" readonly aria-label="67ified C++ source"></textarea>
+    </article>
+  </section>
+
+  <section class="cpp67-actions" aria-label="67ifier actions">
+    <button class="br-primary" id="cpp67-transform" type="button">67ify this program</button>
+    <button class="br-secondary" id="cpp67-copy" type="button">Copy output</button>
+    <button class="br-secondary" id="cpp67-download" type="button">Download .cpp</button>
+    <button class="br-text-button" id="cpp67-sample" type="button">load sample</button>
+    <button class="br-text-button" id="cpp67-reset" type="button">reset</button>
+  </section>
+
+  <section class="cpp67-report" id="cpp67-report" aria-live="polite">
+    <div><span>identifiers renamed</span><strong id="cpp67-name-count">0</strong></div>
+    <div><span>integers transformed</span><strong id="cpp67-integer-count">0</strong></div>
+    <div><span>output size</span><strong id="cpp67-expansion">100%</strong></div>
+    <p id="cpp67-status">Awaiting a scientifically unnecessary program.</p>
+  </section>
+
+  <details class="cpp67-notes">
+    <summary>What can still break?</summary>
+    <p>This is a tokenizer, not a full C++ compiler. Names required by a grader, linked library,
+      reflection system, plugin ABI, or generated code should be added to the preserve list.
+      Identifiers beginning with an underscore are conservatively left alone. Floating-point and
+      user-defined numeric literals are also preserved.</p>
+  </details>
+</main>
+<script type="module" src="{% static 'brainrot/cpp_67ifier.js' %}?v=20260814.1"></script>
+{% endblock %}

--- a/brainrot/templates/brainrot/index.html
+++ b/brainrot/templates/brainrot/index.html
@@ -4,12 +4,12 @@
 {% block title %}Institute of 61/67 Studies{% endblock %}
 
 {% block content %}
-<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}">
+<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260814.7">
 <main class="br-page">
   <section class="br-hero">
     <span class="br-kicker">ICAiJY INSTITUTE OF NUMERICAL CULTURE</span>
     <h1>61 / 67 Research Division</h1>
-    <p>Two controlled experiments. No useful findings are expected.</p>
+    <p>Three controlled experiments. No useful findings are expected.</p>
   </section>
   <section class="br-game-grid" aria-label="Experiments">
     <a class="br-game-card br-counter-card" href="{% url 'brainrot:counter' %}">
@@ -29,6 +29,15 @@
         <p>Modern typing science, stripped of every unnecessary character.</p>
       </div>
       <span class="br-card-arrow">Type →</span>
+    </a>
+    <a class="br-game-card br-code-card" href="{% url 'brainrot:cpp_67ifier' %}">
+      <span class="br-card-number">67^67</span>
+      <div>
+        <span class="br-kicker">EXPERIMENT 03</span>
+        <h2>C++ 67ifier</h2>
+        <p>Convert respectable competitive-programming code into numerically significant research.</p>
+      </div>
+      <span class="br-card-arrow">Corrupt responsibly →</span>
     </a>
   </section>
 </main>

--- a/brainrot/tests.py
+++ b/brainrot/tests.py
@@ -17,13 +17,35 @@ from .views import _validated_event_timeline
 
 class BrainrotPageTests(TestCase):
     def test_public_pages_load(self):
-        for path in ('/67/', '/67/counter/', '/67/hall-of-fame/', '/67/typing/'):
+        for path in ('/67/', '/67/counter/', '/67/hall-of-fame/', '/67/typing/', '/67/67ifier/'):
             with self.subTest(path=path):
                 self.assertEqual(self.client.get(path).status_code, 200)
 
         legacy = self.client.get('/67/games/')
         self.assertEqual(legacy.status_code, 301)
         self.assertEqual(legacy['Location'], '/67/')
+
+    def test_cpp_67ifier_is_linked_and_runs_locally(self):
+        index = self.client.get('/67/')
+        self.assertContains(index, '/67/67ifier/')
+        self.assertContains(index, 'C++ 67ifier')
+
+        response = self.client.get('/67/67ifier/')
+        self.assertContains(response, 'id="cpp67-input"')
+        self.assertContains(response, 'id="cpp67-output"')
+        self.assertContains(response, 'id="cpp67-preserve"')
+        self.assertContains(response, 'cpp_67ifier.js?v=20260814.1')
+        self.assertContains(response, 'transformation happens entirely in this browser')
+
+        script_path = finders.find('brainrot/cpp_67ifier.js')
+        core_path = finders.find('brainrot/cpp_67ifier_core.mjs')
+        self.assertIsNotNone(script_path)
+        self.assertIsNotNone(core_path)
+        script = Path(script_path).read_text(encoding='utf-8')
+        core = Path(core_path).read_text(encoding='utf-8')
+        self.assertIn("from './cpp_67ifier_core.mjs?v=20260814.1'", script)
+        self.assertIn('export function tokenizeCpp', core)
+        self.assertIn('export function transformCpp', core)
 
     def test_counter_uses_cache_busted_runtime_and_has_share_box(self):
         response = self.client.get('/67/counter/')

--- a/brainrot/urls.py
+++ b/brainrot/urls.py
@@ -15,4 +15,5 @@ urlpatterns = [
     path('hall-of-fame/<int:entry_id>/video/', views.hall_of_fame_video, name='hall_of_fame_video'),
     path('challenge/<int:entry_id>/', views.challenge, name='challenge'),
     path('typing/', views.typing_test, name='typing_test'),
+    path('67ifier/', views.cpp_67ifier, name='cpp_67ifier'),
 ]

--- a/brainrot/views.py
+++ b/brainrot/views.py
@@ -50,6 +50,10 @@ def typing_test(request):
     return render(request, 'brainrot/typing.html')
 
 
+def cpp_67ifier(request):
+    return render(request, 'brainrot/cpp_67ifier.html')
+
+
 def hall_of_fame(request):
     entries = HallOfFameEntry.objects.filter(
         state=HallOfFameEntry.State.APPROVED,


### PR DESCRIPTION
## What changed

- add a third experiment at `/67/67ifier/`
- implement a browser-local C++ tokenizer that preserves comments, strings, raw strings, character literals, and preprocessor directives
- consistently rename user identifiers while preserving C++ keywords, common standard-library names, macros, underscore-prefixed names, and a user-defined allowlist
- add common-number and full binary/Horner integer transformation modes
- add copy, `.cpp` download, sample, reset, statistics, warnings, and responsive styling
- link the tool from the existing 61/67 research index
- add Django page/static assertions and six Node unit tests for lexical edge cases

## Why

This turns the proposed “rename everything to sixseven and replace constants with numerical nonsense” idea into a usable joke tool without compiling or uploading untrusted code.

## Validation

- `node --test brainrot/js_tests/cpp_67ifier_core.test.mjs` — 6 passed
- `node --check` for both new JavaScript modules
- generated output from common and full modes passed `g++ -std=c++20 -fsyntax-only`
- `python3 -m compileall -q brainrot myblog`
- `git diff --check`

Full Django tests could not run in the agent container because Django is not installed there; the repository test coverage is included for execution in the project venv/CI.

No migration, Python dependency, frontend package, environment variable, or server-side code execution is added.