### PR TITLE
Fix anonymous HOF and 67 camera flow

### DIFF
--- a/brainrot/models.py
+++ b/brainrot/models.py
@@ -51,7 +51,7 @@ class HallOfFameEntry(models.Model):
     def public_name(self):
         if self.user_id:
             return self.user.username
-        return self.display_name or 'Anonymous Swan'
+        return f"anon · {self.display_name or 'Anonymous Swan'}"
 
 
 class HallOfFameUploadAttempt(models.Model):

--- a/brainrot/models.py
+++ b/brainrot/models.py
@@ -51,7 +51,7 @@ class HallOfFameEntry(models.Model):
     def public_name(self):
         if self.user_id:
             return self.user.username
-        return f"anon · {self.display_name or 'Anonymous Swan'}"
+        return f"{self.display_name or 'Anonymous Swan'} · anon"
 
 
 class HallOfFameUploadAttempt(models.Model):

--- a/brainrot/static/brainrot/counter.js
+++ b/brainrot/static/brainrot/counter.js
@@ -10,7 +10,9 @@ if (app) {
   const countdownEl = document.getElementById('countdown');
   const livePill = document.getElementById('live-pill');
   const enableButton = document.getElementById('enable-camera');
-  const startButton = document.getElementById('start-run');
+  // There is intentionally only one primary run button. Before camera access it
+  // enables the camera; afterwards the same control becomes the readiness button.
+  const startButton = enableButton;
   const resetButton = document.getElementById('reset-run');
   const errorEl = document.getElementById('counter-error');
   const resultCard = document.getElementById('counter-result');
@@ -142,6 +144,12 @@ if (app) {
 
   function delay(milliseconds) {
     return new Promise((resolve) => window.setTimeout(resolve, milliseconds));
+  }
+
+  function nextPaint() {
+    return new Promise((resolve) => {
+      requestAnimationFrame(() => requestAnimationFrame(resolve));
+    });
   }
 
   function csrfToken() {
@@ -302,6 +310,7 @@ if (app) {
 
   async function initialiseDetector() {
     enableButton.disabled = true;
+    enableButton.textContent = 'Enabling camera…';
     setStatus('Requesting camera permission…', 'busy');
     showError('');
     try {
@@ -312,14 +321,22 @@ if (app) {
       video.srcObject = stream;
       await video.play();
       placeholder.hidden = true;
-      setStatus(landmarker ? 'Pose model ready' : 'Finishing pose model preload…', 'busy');
+      enableButton.textContent = landmarker ? READY_LABEL : 'Loading pose detector…';
+      setStatus(landmarker ? 'Pose model ready' : 'Camera live — finishing pose model preload…', 'busy');
+
+      // Let the browser paint the live camera before MediaPipe finishes its
+      // heavier WASM/model initialisation. On a cold cache this can take a few
+      // seconds, but the UI no longer looks frozen while it happens.
+      await nextPaint();
       await initialisePoseRuntime();
-      enableButton.hidden = true;
+
       startButton.disabled = false;
       startButton.textContent = READY_LABEL;
+      setStatus('Detector ready — click I\'m ready, then step into frame', 'ready');
       detectorLoop = requestAnimationFrame(detectFrame);
     } catch (error) {
       enableButton.disabled = false;
+      enableButton.textContent = 'Enable camera';
       if (stream) {
         stream.getTracks().forEach((track) => track.stop());
         stream = null;
@@ -568,8 +585,22 @@ if (app) {
     copyShareStatus.textContent = '';
     resetButton.hidden = true;
     startButton.disabled = !landmarker;
-    startButton.textContent = landmarker ? READY_LABEL : 'Detector is still loading…';
+    startButton.textContent = landmarker ? READY_LABEL : 'Loading pose detector…';
     showError('');
+  }
+
+  async function responsePayload(response) {
+    const contentType = response.headers.get('content-type') || '';
+    if (contentType.includes('application/json')) {
+      return response.json();
+    }
+    const text = await response.text();
+    const summary = text.replace(/<[^>]*>/g, ' ').replace(/\s+/g, ' ').trim().slice(0, 180);
+    return {
+      error: summary
+        ? `Upload failed (${response.status}). Server response: ${summary}`
+        : `Upload failed (${response.status}). The server returned a non-JSON response.`,
+    };
   }
 
   async function submitRecording() {
@@ -595,10 +626,13 @@ if (app) {
       const response = await fetch(app.dataset.submitUrl, {
         method: 'POST',
         body: form,
-        headers: { 'X-CSRFToken': csrfToken() },
+        headers: {
+          'X-CSRFToken': csrfToken(),
+          'Accept': 'application/json',
+        },
         credentials: 'same-origin',
       });
-      const payload = await response.json();
+      const payload = await responsePayload(response);
       if (!response.ok) throw new Error(payload.error || 'Upload failed.');
       uploadStatus.textContent = payload.message;
       submitButton.hidden = true;
@@ -612,8 +646,10 @@ if (app) {
   }
 
   preloadPoseRuntime();
-  enableButton.addEventListener('click', initialiseDetector);
-  startButton.addEventListener('click', armRun);
+  enableButton.addEventListener('click', () => {
+    if (stream) armRun();
+    else initialiseDetector();
+  });
   resetButton.addEventListener('click', resetRun);
   submitButton?.addEventListener('click', submitRecording);
   discardButton?.addEventListener('click', discardRecording);

--- a/brainrot/templates/brainrot/counter.html
+++ b/brainrot/templates/brainrot/counter.html
@@ -18,7 +18,7 @@
     <a href="{% url 'brainrot:index' %}">← Research division</a>
     <div class="br-toolbar-links">
       {% if request.user.is_authenticated %}<a href="{% url 'brainrot:my_hall_of_fame' %}">My HOF</a>{% endif %}
-      <a href="{% url 'brainrot:hall_of_fame' %}">Hall of Fame</a>
+      <a class="br-primary br-button-link" href="{% url 'brainrot:hall_of_fame' %}">🏆 Hall of Fame</a>
     </div>
   </header>
 
@@ -90,8 +90,7 @@
       {% endif %}
 
       <button class="br-primary" id="enable-camera">Enable camera</button>
-      <button class="br-primary" id="start-run" disabled>Detector is still loading…</button>
-      <p class="subtle run-consent">I'm ready starts a local recording. Submitting remains your decision.</p>
+      <p class="subtle run-consent">After the camera is enabled, this same button becomes “I'm ready”. Starting a run records locally; submitting remains your decision.</p>
       <button class="br-secondary" id="reset-run" hidden>Run this foolish experiment again</button>
       <p class="counter-error" id="counter-error" role="alert"></p>
     </aside>
@@ -112,8 +111,7 @@
           <span>Anonymous display name</span>
           <input id="hof-display-name" maxlength="32" placeholder="Anonymous Swan">
         </label>
-        <p class="subtle">No account means no ownership recovery or delete button later.
-          <a href="{% url 'login' %}?next={{ request.path|urlencode }}">Log in before another run</a> if you want those controls.</p>
+        <p class="subtle">Anonymous entries are always marked <strong>anon ·</strong> and cannot use an existing registered username. They are not tied to an account, so there is no self-service delete button; if you need one removed later, contact me with its Hall of Fame link. <a href="{% url 'login' %}?next={{ request.path|urlencode }}">Log in before another run</a> if you want direct ownership controls.</p>
       {% elif request.user.is_authenticated %}
         <p class="subtle">Submitting as <strong>{{ request.user.username }}</strong>. This run will appear in My HOF and can be deleted later.</p>
       {% else %}
@@ -143,5 +141,5 @@
 {% endif %}
 
 {# Keep this version in step with counter.js so browsers cannot retain a broken runtime URL. #}
-<script type="module" src="{% static 'brainrot/counter.js' %}?v=20260814.12"></script>
+<script type="module" src="{% static 'brainrot/counter.js' %}?v=20260814.12&ui=1"></script>
 {% endblock %}

--- a/brainrot/templates/brainrot/counter.html
+++ b/brainrot/templates/brainrot/counter.html
@@ -111,7 +111,7 @@
           <span>Anonymous display name</span>
           <input id="hof-display-name" maxlength="32" placeholder="Anonymous Swan">
         </label>
-        <p class="subtle">Anonymous entries are always marked <strong>anon ·</strong> and cannot use an existing registered username. They are not tied to an account, so there is no self-service delete button; if you need one removed later, contact me with its Hall of Fame link. <a href="{% url 'login' %}?next={{ request.path|urlencode }}">Log in before another run</a> if you want direct ownership controls.</p>
+        <p class="subtle">Anonymous entries are always marked <strong>· anon</strong> and cannot use an existing registered username. They are not tied to an account, so there is no self-service delete button; if you need one removed later, contact me with its Hall of Fame link. <a href="{% url 'login' %}?next={{ request.path|urlencode }}">Log in before another run</a> if you want direct ownership controls.</p>
       {% elif request.user.is_authenticated %}
         <p class="subtle">Submitting as <strong>{{ request.user.username }}</strong>. This run will appear in My HOF and can be deleted later.</p>
       {% else %}

--- a/brainrot/templates/brainrot/hall_of_fame_detail.html
+++ b/brainrot/templates/brainrot/hall_of_fame_detail.html
@@ -36,8 +36,10 @@
     <aside class="hall-share-card">
       <span class="br-kicker">PUBLIC REPLICATION MATERIAL</span>
       <h2>Share this run</h2>
-      {% if request.user == entry.user %}
+      {% if request.user == entry.user and entry.user_id %}
       <p>This is your permanent Hall of Fame link. Deploy it responsibly.</p>
+      {% elif not entry.user_id %}
+      <p>This is an anonymous entry and is not tied to an account. There is no self-service delete button; contact me with this Hall of Fame link if you need the entry removed.</p>
       {% else %}
       <p>Distribute this evidence to researchers, rivals and confused relatives.</p>
       {% endif %}

--- a/brainrot/templates/brainrot/index.html
+++ b/brainrot/templates/brainrot/index.html
@@ -10,6 +10,7 @@
     <span class="br-kicker">ICAiJY INSTITUTE OF NUMERICAL CULTURE</span>
     <h1>61 / 67 Research Division</h1>
     <p>Two controlled experiments. No useful findings are expected.</p>
+    <p><a class="br-primary br-button-link" href="{% url 'brainrot:hall_of_fame' %}">🏆 Browse the 67 Hall of Fame →</a></p>
   </section>
   <section class="br-game-grid" aria-label="Experiments">
     <a class="br-game-card br-counter-card" href="{% url 'brainrot:counter' %}">

--- a/brainrot/views.py
+++ b/brainrot/views.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 
 import requests
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import ValidationError
 from django.db import transaction
@@ -20,6 +21,13 @@ from django.views.decorators.http import require_POST
 
 from .models import HallOfFameEntry, HallOfFameUploadAttempt
 from .validators import validate_hall_of_fame_video
+
+
+TURNSTILE_TEST_SECRETS = {
+    '1x0000000000000000000000000000000AA',
+    '2x0000000000000000000000000000000AA',
+    '3x0000000000000000000000000000000AA',
+}
 
 
 def index(request):
@@ -126,11 +134,14 @@ def _turnstile_is_valid(request):
         )
         result = response.json()
         expected_hostname = request.get_host().split(':', 1)[0].lower()
-        return (
-            response.ok
-            and result.get('success') is True
-            and result.get('hostname', '').lower() == expected_hostname
+        # Cloudflare's official test secrets deliberately report localhost even
+        # when their dummy widget is embedded on another development host. Real
+        # secrets must still match the actual request hostname.
+        hostname_matches = (
+            settings.TURNSTILE_SECRET_KEY in TURNSTILE_TEST_SECRETS
+            or result.get('hostname', '').lower() == expected_hostname
         )
+        return response.ok and result.get('success') is True and hostname_matches
     except (requests.RequestException, ValueError):
         return False
 
@@ -150,13 +161,15 @@ def _upload_client_key(request):
 
 
 def _anonymous_display_name(raw_name):
-    name = ' '.join((raw_name or '').strip().split())
+    name = unicodedata.normalize('NFKC', ' '.join((raw_name or '').strip().split()))
     if not name:
         return 'Anonymous Swan'
     if len(name) > 32:
         raise ValidationError('Display name must be 32 characters or fewer.')
     if any(unicodedata.category(character).startswith('C') for character in name):
         raise ValidationError('Display name contains an unsupported character.')
+    if get_user_model().objects.filter(username__iexact=name).exists():
+        raise ValidationError('That name belongs to a registered user. Choose a different anonymous display name.')
     return name
 
 
@@ -231,7 +244,7 @@ def submit_hall_of_fame(request):
         'message': (
             'Published to the Hall of Fame. You can manage it from My HOF.'
             if owner
-            else 'Published anonymously. Save the public link; anonymous runs cannot be managed later.'
+            else 'Published anonymously. Save the public link; contact the site owner with that link if you need it removed later.'
         ),
         'hall_of_fame_url': reverse('brainrot:hall_of_fame'),
         'entry_url': entry_url,

--- a/brainrot/views.py
+++ b/brainrot/views.py
@@ -244,7 +244,7 @@ def submit_hall_of_fame(request):
         'message': (
             'Published to the Hall of Fame. You can manage it from My HOF.'
             if owner
-            else 'Published anonymously. Save the public link; contact the site owner with that link if you need it removed later.'
+            else 'Published anonymously. This run cannot be managed later through an account; save the public link and contact the site owner with it if you need the entry removed.'
         ),
         'hall_of_fame_url': reverse('brainrot:hall_of_fame'),
         'entry_url': entry_url,

--- a/homepage/templates/homepage/index.html
+++ b/homepage/templates/homepage/index.html
@@ -127,14 +127,14 @@
         <a href="/orac-leaderboards" class="nav-card btn-leader">
             🏆 ORAC Leaderboards++
         </a>
-        <a href="/oj" class="nav-card btn-oj">
-            🪦 {% trans "Speed Online Judge" %} (retired)
-        </a>
         <a href="/oracdata" class="nav-card btn-analytics">
             📊 {% trans "ORAC2 Analytics" %}
         </a>
         <a href="{% url 'brainrot:index' %}" class="nav-card btn-brainrot">
             🧪 61/67 Research Division
+        </a>
+        <a href="/oj" class="nav-card btn-oj">
+            🪦 {% trans "Speed Online Judge" %} (retired)
         </a>
     </div>
 </div>


### PR DESCRIPTION
## What changed

- fix anonymous Hall of Fame submissions when the official Cloudflare Turnstile test keys are used by accepting their documented `localhost` test hostname while keeping strict hostname checks for real secrets
- stop assuming every upload response is JSON, so CSRF/proxy/server HTML errors produce a useful status instead of `JSON.parse: unexpected character`
- replace the separate `Enable camera` and `I'm ready` controls with one primary button whose action/label changes after camera access
- show the live camera before waiting for the heavier MediaPipe model/WASM initialisation, with clearer loading state
- prevent anonymous display names from matching registered usernames and visibly suffix every anonymous HOF identity with `· anon`
- clarify that anonymous entries have no self-service deletion but can be removed by contacting the site owner with the HOF link
- make Hall of Fame links more prominent from the 61/67 hub and Counter toolbar
- move the retired OJ/OI card lower on the homepage

## Root causes

The Counter template rendered both camera controls at once. Camera access itself completed before the pose runtime, but the UI then awaited MediaPipe initialisation, making a cold load look like the camera had stalled. Anonymous upload errors were also parsed with unconditional `response.json()`, hiding any HTML response from CSRF/proxy layers. Finally, Cloudflare's official dummy Turnstile validation response reports `hostname: localhost`, while the backend previously required the request hostname even for test secrets.

## Validation

- reviewed the branch diff against `main`
- retained existing Counter test anchors/version substring and anonymous-submission compatibility strings
- no database migration or new dependency

The execution container in this session cannot resolve GitHub/Django dependencies, so the Django/Node suites were not run locally. Please run the existing `brainrot` tests and `node --check brainrot/static/brainrot/counter.js` before merging if CI is not available.