### PR TITLE
Fix anonymous HOF submission and camera UX

### DIFF
--- a/brainrot/models.py
+++ b/brainrot/models.py
@@ -51,7 +51,7 @@ class HallOfFameEntry(models.Model):
     def public_name(self):
         if self.user_id:
             return self.user.username
-        return self.display_name or 'Anonymous Swan'
+        return f'{self.display_name or "Anonymous Swan"} · guest'
 
 
 class HallOfFameUploadAttempt(models.Model):

--- a/brainrot/static/brainrot/brainrot.css
+++ b/brainrot/static/brainrot/brainrot.css
@@ -43,6 +43,8 @@
 .br-toolbar a { color: var(--br-ink); font-weight: 750; text-decoration: none; }
 .br-toolbar a:hover { color: var(--br-accent-dark); }
 .br-toolbar-links { display: flex; gap: 1rem; }
+.br-toolbar .hof-nav-link { padding: .28rem .6rem; border-radius: 999px; background: var(--br-ink); color: var(--br-lime); }
+.br-toolbar .hof-nav-link:hover { color: white; }
 
 .br-hero { max-width: 880px; padding: 3rem 0 4rem; }
 .br-hero h1, .counter-intro h1, .typing-heading h1, .hall-heading h1 {
@@ -83,6 +85,12 @@
   line-height: 1;
 }
 .br-card-arrow { position: absolute; left: 2rem; bottom: 2rem; font-weight: 850; }
+.br-hof-banner { display: flex; align-items: center; justify-content: space-between; gap: 2rem; margin: -1.5rem 0 1.2rem; padding: 1.5rem 1.7rem; border-radius: 20px; background: var(--br-ink); color: white; text-decoration: none; box-shadow: 0 16px 40px rgba(15,23,42,.16); transition: transform .18s ease, box-shadow .18s ease; }
+.br-hof-banner:hover { color: white; transform: translateY(-3px); box-shadow: 0 22px 48px rgba(15,23,42,.22); }
+.br-hof-banner .br-kicker { color: var(--br-lime); }
+.br-hof-banner h2 { margin: .15rem 0 .25rem; font-size: 2rem; font-weight: 900; }
+.br-hof-banner p { margin: 0; color: #cbd5e1; }
+.br-hof-banner > strong { flex: 0 0 auto; color: var(--br-lime); }
 
 .privacy-strip {
   margin: 2rem 0;
@@ -292,6 +300,7 @@
   .hall-detail-heading { align-items: start; flex-direction: column; gap: .6rem; }
   .hall-detail-heading .br-kicker { position: static; transform: none; }
   .typing-viewport { height: 205px; padding: 1.3rem; }
+  .br-hof-banner { align-items: flex-start; flex-direction: column; margin-top: -2rem; }
 }
 
 @media (prefers-reduced-motion: reduce) {

--- a/brainrot/static/brainrot/counter.js
+++ b/brainrot/static/brainrot/counter.js
@@ -35,6 +35,7 @@ if (app) {
   const GO_DISPLAY_MS = 250;
   const RECORDING_LEAD_SECONDS = 3 + GO_DISPLAY_MS / 1000;
   const READY_LABEL = "I'm ready — record locally";
+  const MODEL_URL = 'https://storage.googleapis.com/mediapipe-models/pose_landmarker/pose_landmarker_lite/float16/1/pose_landmarker_lite.task';
   const rivalTimeline = rivalTimelineNode ? JSON.parse(rivalTimelineNode.textContent) : [];
   const rivalName = app.dataset.rivalName || '';
   const rivalFinalScore = Number(app.dataset.rivalScore || 0);
@@ -95,10 +96,13 @@ if (app) {
       runtimePromise = (async () => {
         const { FilesetResolver, PoseLandmarker, wasmRoot } = await loadMediaPipe();
         const vision = await FilesetResolver.forVisionTasks(wasmRoot);
+        // Firefox can spend several seconds failing the GPU delegate before
+        // repeating the same initialisation on CPU. Start on CPU there.
+        const preferCpu = /Firefox\//.test(navigator.userAgent);
         const options = {
           baseOptions: {
-            modelAssetPath: 'https://storage.googleapis.com/mediapipe-models/pose_landmarker/pose_landmarker_lite/float16/1/pose_landmarker_lite.task',
-            delegate: 'GPU',
+            modelAssetPath: MODEL_URL,
+            delegate: preferCpu ? 'CPU' : 'GPU',
           },
           runningMode: 'VIDEO',
           numPoses: 1,
@@ -109,6 +113,7 @@ if (app) {
         try {
           landmarker = await PoseLandmarker.createFromOptions(vision, options);
         } catch (gpuError) {
+          if (preferCpu) throw gpuError;
           options.baseOptions.delegate = 'CPU';
           landmarker = await PoseLandmarker.createFromOptions(vision, options);
         }
@@ -312,14 +317,19 @@ if (app) {
       video.srcObject = stream;
       await video.play();
       placeholder.hidden = true;
+      enableButton.hidden = true;
+      startButton.hidden = false;
+      startButton.disabled = true;
+      startButton.textContent = landmarker ? READY_LABEL : 'Finishing detector setup…';
       setStatus(landmarker ? 'Pose model ready' : 'Finishing pose model preload…', 'busy');
       await initialisePoseRuntime();
-      enableButton.hidden = true;
       startButton.disabled = false;
       startButton.textContent = READY_LABEL;
       detectorLoop = requestAnimationFrame(detectFrame);
     } catch (error) {
       enableButton.disabled = false;
+      enableButton.hidden = false;
+      startButton.hidden = true;
       if (stream) {
         stream.getTracks().forEach((track) => track.stop());
         stream = null;
@@ -459,6 +469,7 @@ if (app) {
     }
     armed = false;
     countdownActive = true;
+    startButton.hidden = true;
     setStatus('Pose locked — countdown commencing', 'ready');
 
     try {
@@ -475,6 +486,7 @@ if (app) {
       }
       showError(error.message);
       countdownActive = false;
+      startButton.hidden = false;
       startButton.disabled = false;
       startButton.textContent = READY_LABEL;
       return;
@@ -532,6 +544,7 @@ if (app) {
       recordingDownload.download = blob.type === 'video/mp4' ? '67-run.mp4' : '67-run.webm';
       recordingDownload.hidden = false;
     }
+    startButton.hidden = true;
     resetButton.hidden = false;
     resultCard.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
   }
@@ -567,6 +580,7 @@ if (app) {
     shareText.value = '';
     copyShareStatus.textContent = '';
     resetButton.hidden = true;
+    startButton.hidden = false;
     startButton.disabled = !landmarker;
     startButton.textContent = landmarker ? READY_LABEL : 'Detector is still loading…';
     showError('');
@@ -598,7 +612,20 @@ if (app) {
         headers: { 'X-CSRFToken': csrfToken() },
         credentials: 'same-origin',
       });
-      const payload = await response.json();
+      const rawResponse = await response.text();
+      let payload;
+      try {
+        payload = JSON.parse(rawResponse);
+      } catch {
+        const statusHint = response.status === 403
+          ? 'Security check rejected the upload. Refresh this page and try again.'
+          : response.status === 413
+            ? 'The web server rejected the recording as too large.'
+            : response.status >= 500
+              ? `The server returned HTTP ${response.status}. The site owner may need to run database migrations or inspect the server log.`
+              : `The server returned HTTP ${response.status} instead of JSON.`;
+        throw new Error(statusHint);
+      }
       if (!response.ok) throw new Error(payload.error || 'Upload failed.');
       uploadStatus.textContent = payload.message;
       submitButton.hidden = true;

--- a/brainrot/templates/brainrot/counter.html
+++ b/brainrot/templates/brainrot/counter.html
@@ -6,7 +6,9 @@
 {% block content %}
 <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
 <link rel="preconnect" href="https://storage.googleapis.com" crossorigin>
-<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260814.7">
+<link rel="modulepreload" href="https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@1.0.1/vision_bundle.mjs" crossorigin>
+<link rel="preload" href="https://storage.googleapis.com/mediapipe-models/pose_landmarker/pose_landmarker_lite/float16/1/pose_landmarker_lite.task" as="fetch" crossorigin>
+<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260814.8">
 {% if turnstile_enabled %}<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>{% endif %}
 
 <main class="br-page counter-page" id="counter-app"
@@ -18,7 +20,7 @@
     <a href="{% url 'brainrot:index' %}">← Research division</a>
     <div class="br-toolbar-links">
       {% if request.user.is_authenticated %}<a href="{% url 'brainrot:my_hall_of_fame' %}">My HOF</a>{% endif %}
-      <a href="{% url 'brainrot:hall_of_fame' %}">Hall of Fame</a>
+      <a class="hof-nav-link" href="{% url 'brainrot:hall_of_fame' %}">★ Hall of Fame</a>
     </div>
   </header>
 
@@ -90,7 +92,7 @@
       {% endif %}
 
       <button class="br-primary" id="enable-camera">Enable camera</button>
-      <button class="br-primary" id="start-run" disabled>Detector is still loading…</button>
+      <button class="br-primary" id="start-run" disabled hidden>Detector is still loading…</button>
       <p class="subtle run-consent">I'm ready starts a local recording. Submitting remains your decision.</p>
       <button class="br-secondary" id="reset-run" hidden>Run this foolish experiment again</button>
       <p class="counter-error" id="counter-error" role="alert"></p>
@@ -112,8 +114,10 @@
           <span>Anonymous display name</span>
           <input id="hof-display-name" maxlength="32" placeholder="Anonymous Swan">
         </label>
-        <p class="subtle">No account means no ownership recovery or delete button later.
-          <a href="{% url 'login' %}?next={{ request.path|urlencode }}">Log in before another run</a> if you want those controls.</p>
+        <p class="subtle">Guest runs are always labelled “guest” and cannot impersonate registered usernames.
+          They have no self-service delete button. To remove one later,
+          <a href="https://github.com/icaijy" rel="noopener">contact me</a> with its public HOF link.
+          <a href="{% url 'login' %}?next={{ request.path|urlencode }}">Log in before another run</a> if you want ownership controls.</p>
       {% elif request.user.is_authenticated %}
         <p class="subtle">Submitting as <strong>{{ request.user.username }}</strong>. This run will appear in My HOF and can be deleted later.</p>
       {% else %}
@@ -143,5 +147,5 @@
 {% endif %}
 
 {# Keep this version in step with counter.js so browsers cannot retain a broken runtime URL. #}
-<script type="module" src="{% static 'brainrot/counter.js' %}?v=20260814.12"></script>
+<script type="module" src="{% static 'brainrot/counter.js' %}?v=20260814.13"></script>
 {% endblock %}

--- a/brainrot/templates/brainrot/hall_of_fame.html
+++ b/brainrot/templates/brainrot/hall_of_fame.html
@@ -4,7 +4,7 @@
 {% block title %}67 Hall of Fame{% endblock %}
 
 {% block content %}
-<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260814.7">
+<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260814.8">
 <main class="br-page hall-page">
   <header class="br-toolbar">
     <a href="{% url 'brainrot:counter' %}">← 67 Counter</a>
@@ -17,7 +17,8 @@
   <section class="hall-heading">
     <span class="br-kicker">PUBLIC ARCHIVE OF EXCEPTIONAL ARM ACTIVITY</span>
     <h1>67 Hall of Fame</h1>
-    <p>Valid uploads appear immediately. Obvious high-technology specimens may disappear without ceremony.</p>
+    <p>Valid uploads appear immediately. Guest names are visibly labelled and cannot copy registered usernames.
+      Obvious high-technology specimens may disappear without ceremony.</p>
   </section>
 
   <section class="hall-list">

--- a/brainrot/templates/brainrot/hall_of_fame_detail.html
+++ b/brainrot/templates/brainrot/hall_of_fame_detail.html
@@ -4,7 +4,7 @@
 {% block title %}{{ entry.public_name }} — 67 Hall of Fame{% endblock %}
 
 {% block content %}
-<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260814.7">
+<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260814.8">
 <main class="br-page hall-detail-page" id="hof-detail"
       data-entry-url="{{ request.build_absolute_uri }}"
       data-username="{{ entry.public_name }}"
@@ -36,8 +36,11 @@
     <aside class="hall-share-card">
       <span class="br-kicker">PUBLIC REPLICATION MATERIAL</span>
       <h2>Share this run</h2>
-      {% if request.user == entry.user %}
+      {% if entry.user_id and request.user == entry.user %}
       <p>This is your permanent Hall of Fame link. Deploy it responsibly.</p>
+      {% elif not entry.user_id %}
+      <p>This is a guest submission and has no self-service delete access. To request removal,
+        <a href="https://github.com/icaijy" rel="noopener">contact the site owner</a> and include this page's URL.</p>
       {% else %}
       <p>Distribute this evidence to researchers, rivals and confused relatives.</p>
       {% endif %}

--- a/brainrot/templates/brainrot/index.html
+++ b/brainrot/templates/brainrot/index.html
@@ -4,13 +4,21 @@
 {% block title %}Institute of 61/67 Studies{% endblock %}
 
 {% block content %}
-<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}">
+<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260814.8">
 <main class="br-page">
   <section class="br-hero">
     <span class="br-kicker">ICAiJY INSTITUTE OF NUMERICAL CULTURE</span>
     <h1>61 / 67 Research Division</h1>
     <p>Two controlled experiments. No useful findings are expected.</p>
   </section>
+  <a class="br-hof-banner" href="{% url 'brainrot:hall_of_fame' %}">
+    <div>
+      <span class="br-kicker">PUBLIC VIDEO ARCHIVE</span>
+      <h2>67 Hall of Fame</h2>
+      <p>Watch the evidence, share a specimen, or challenge somebody's recorded count.</p>
+    </div>
+    <strong>Enter the archive →</strong>
+  </a>
   <section class="br-game-grid" aria-label="Experiments">
     <a class="br-game-card br-counter-card" href="{% url 'brainrot:counter' %}">
       <span class="br-card-number">67</span>

--- a/brainrot/tests.py
+++ b/brainrot/tests.py
@@ -28,8 +28,8 @@ class BrainrotPageTests(TestCase):
     @override_settings(DEBUG=True)
     def test_counter_uses_cache_busted_runtime_and_has_share_box(self):
         response = self.client.get('/67/counter/')
-        self.assertContains(response, 'brainrot.css?v=20260814.7')
-        self.assertContains(response, 'counter.js?v=20260814.12')
+        self.assertContains(response, 'brainrot.css?v=20260814.8')
+        self.assertContains(response, 'counter.js?v=20260814.13')
         self.assertContains(response, 'id="counter-share-text"')
         self.assertContains(response, 'id="copy-counter-share"')
         self.assertContains(response, 'id="download-recording"')
@@ -38,6 +38,8 @@ class BrainrotPageTests(TestCase):
         self.assertContains(response, 'nothing uploads unless you press Submit to Hall of Fame')
         self.assertContains(response, 'id="submit-hof"')
         self.assertContains(response, 'id="hof-display-name"')
+        self.assertContains(response, 'id="start-run" disabled hidden')
+        self.assertContains(response, '★ Hall of Fame')
         self.assertNotContains(response, 'Log in to submit this run')
 
         script_path = finders.find('brainrot/counter.js')
@@ -59,6 +61,12 @@ class BrainrotPageTests(TestCase):
         self.assertNotIn('recorder = new MediaRecorder(stream', script)
         self.assertIn("form.append('event_timeline', JSON.stringify(eventTimeline));", script)
         self.assertIn("form.append('display_name', displayNameInput.value);", script)
+        self.assertIn("const rawResponse = await response.text();", script)
+        self.assertIn('payload = JSON.parse(rawResponse);', script)
+        self.assertNotIn('await response.json()', script)
+        self.assertIn("const preferCpu = /Firefox\\//.test(navigator.userAgent);", script)
+        self.assertIn("delegate: preferCpu ? 'CPU' : 'GPU'", script)
+        self.assertLess(script.index('enableButton.hidden = true;'), script.index('await initialisePoseRuntime();', script.index('async function initialiseDetector')))
 
 
 class HallOfFamePageTests(TestCase):
@@ -118,6 +126,8 @@ class HallOfFamePageTests(TestCase):
         )
         detail = self.client.get(f'/67/hall-of-fame/{anonymous.id}/')
         self.assertContains(detail, 'Nameless Researcher')
+        self.assertContains(detail, 'guest')
+        self.assertContains(detail, 'contact the site owner')
         self.assertNotContains(detail, 'Delete my entry')
 
         challenge = self.client.get(f'/67/challenge/{anonymous.id}/')
@@ -231,7 +241,7 @@ class HallOfFameSubmissionTests(TestCase):
         entry = HallOfFameEntry.objects.get()
         self.assertIsNone(entry.user)
         self.assertEqual(entry.display_name, 'Anonymous Swan 67')
-        self.assertIn('cannot be managed later', response.json()['message'])
+        self.assertIn('send the public link', response.json()['message'])
 
         attempt = HallOfFameUploadAttempt.objects.get()
         self.assertEqual(len(attempt.client_key), 64)
@@ -240,6 +250,25 @@ class HallOfFameSubmissionTests(TestCase):
         second = SimpleUploadedFile('run.webm', b'more evidence', content_type='video/webm')
         response = self.client.post('/67/submit/', {'score': 68, 'video': second}, REMOTE_ADDR='203.0.113.67')
         self.assertEqual(response.status_code, 429)
+
+    def test_anonymous_name_cannot_impersonate_registered_user(self):
+        response = self.client.post('/67/submit/', {
+            'score': 1,
+            'display_name': 'ＳＣＩＥＮＴＩＳＴ',
+            'event_timeline': '[1.0]',
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('registered user', response.json()['error'])
+        self.assertEqual(HallOfFameEntry.objects.count(), 0)
+
+    def test_anonymous_name_cannot_claim_reserved_admin_role(self):
+        response = self.client.post('/67/submit/', {
+            'score': 1,
+            'display_name': 'ＡＤＭＩＮ',
+            'event_timeline': '[1.0]',
+        })
+        self.assertEqual(response.status_code, 400)
+        self.assertIn('reserved site role', response.json()['error'])
 
     @patch('brainrot.views.validate_hall_of_fame_video')
     def test_valid_upload_is_published_and_rate_limited(self, validate):

--- a/brainrot/views.py
+++ b/brainrot/views.py
@@ -7,6 +7,7 @@ from datetime import timedelta
 
 import requests
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import ValidationError
 from django.db import transaction
@@ -157,6 +158,14 @@ def _anonymous_display_name(raw_name):
         raise ValidationError('Display name must be 32 characters or fewer.')
     if any(unicodedata.category(character).startswith('C') for character in name):
         raise ValidationError('Display name contains an unsupported character.')
+    canonical_name = unicodedata.normalize('NFKC', name).casefold()
+    reserved_names = {'admin', 'administrator', 'moderator', 'staff', 'owner', 'icaijy'}
+    registered_names = {
+        unicodedata.normalize('NFKC', username).casefold()
+        for username in get_user_model().objects.values_list('username', flat=True)
+    }
+    if canonical_name in reserved_names or canonical_name in registered_names:
+        raise ValidationError('That display name belongs to a registered user or reserved site role.')
     return name
 
 
@@ -231,7 +240,7 @@ def submit_hall_of_fame(request):
         'message': (
             'Published to the Hall of Fame. You can manage it from My HOF.'
             if owner
-            else 'Published anonymously. Save the public link; anonymous runs cannot be managed later.'
+            else 'Published as a guest. To remove it later, send the public link to the site owner.'
         ),
         'hall_of_fame_url': reverse('brainrot:hall_of_fame'),
         'entry_url': entry_url,

--- a/homepage/templates/homepage/index.html
+++ b/homepage/templates/homepage/index.html
@@ -71,6 +71,36 @@
         margin-top: 40px;
     }
 
+    #homepage-wrapper .featured-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+        max-width: 900px;
+        margin-top: 10px;
+    }
+
+    #homepage-wrapper .featured-hof {
+        grid-column: 1 / -1;
+        min-height: 105px;
+        font-size: 1.35rem;
+    }
+
+    #homepage-wrapper .oi-section {
+        width: 100%;
+        max-width: 900px;
+        margin-top: 55px;
+        padding-top: 28px;
+        border-top: 1px solid #e2e8f0;
+    }
+
+    #homepage-wrapper .section-label {
+        color: #64748b;
+        font-size: .75rem;
+        font-weight: 800;
+        letter-spacing: .12em;
+        text-transform: uppercase;
+    }
+
+    #homepage-wrapper .oi-section .button-grid { margin-top: 16px; }
+
     #homepage-wrapper .nav-card {
         padding: 24px;
         border-radius: 16px;
@@ -97,45 +127,57 @@
     .btn-oj { background: #fffbeb; color: #b45309; border-color: #fef3c7; }
     .btn-analytics { background: #faf5ff; color: #7e22ce; border-color: #f3e8ff; }
     .btn-brainrot { background: #fff7ed; color: #c2410c; border-color: #fed7aa; }
+    .btn-hof { background: #111827; color: #d8ff62; border-color: #111827; }
+    .btn-hof:hover { color: #d8ff62; }
 
     @media (max-width: 600px) {
         #homepage-wrapper h1 { font-size: 2.5rem; }
-        #homepage-wrapper .button-grid { grid-template-columns: 1fr; }
+        #homepage-wrapper .button-grid, #homepage-wrapper .featured-grid { grid-template-columns: 1fr; }
+        #homepage-wrapper .featured-hof { grid-column: auto; }
     }
 </style>
 
 <div id="homepage-wrapper">
     <div class="hero-section">
         <h1>{% trans "Welcome to My Homepage" %}</h1>
-        <p class="lead">{% trans "Explore projects, data, and insights in one place." %}</p>
+        <p class="lead">{% trans "Projects, questionable experiments, and an archive of competitive-programming history." %}</p>
 
         <div class="quick-links">
             <p>
                 {% trans "Check out my" %}
                 <a href="/blog">{% trans "blog" %}</a>,
-                <a href="/orac-leaderboards">ORAC Leaderboards++</a>,
+                <a href="{% url 'brainrot:hall_of_fame' %}">67 Hall of Fame</a>,
                 {% trans "or" %}
                 <a href="{% url 'brainrot:index' %}">61/67 Research Division</a>.
             </p>
         </div>
     </div>
 
-    <div class="button-grid">
-        <a href="/blog" class="nav-card btn-blog">
-            ✍️ {% trans "Henry's Blog" %}
-        </a>
-        <a href="/orac-leaderboards" class="nav-card btn-leader">
-            🏆 ORAC Leaderboards++
-        </a>
-        <a href="/oj" class="nav-card btn-oj">
-            🪦 {% trans "Speed Online Judge" %} (retired)
-        </a>
-        <a href="/oracdata" class="nav-card btn-analytics">
-            📊 {% trans "ORAC2 Analytics" %}
+    <div class="button-grid featured-grid">
+        <a href="{% url 'brainrot:hall_of_fame' %}" class="nav-card btn-hof featured-hof">
+            ★ 67 Hall of Fame — watch, share, challenge
         </a>
         <a href="{% url 'brainrot:index' %}" class="nav-card btn-brainrot">
             🧪 61/67 Research Division
         </a>
+        <a href="/blog" class="nav-card btn-blog">
+            ✍️ {% trans "Henry's Blog" %}
+        </a>
     </div>
+
+    <section class="oi-section">
+      <span class="section-label">OI / competitive programming archive</span>
+      <div class="button-grid">
+        <a href="/orac-leaderboards" class="nav-card btn-leader">
+            🏆 ORAC Leaderboards++
+        </a>
+        <a href="/oracdata" class="nav-card btn-analytics">
+            📊 {% trans "ORAC2 Analytics" %}
+        </a>
+        <a href="/oj" class="nav-card btn-oj">
+            🪦 {% trans "Speed Online Judge" %} (retired)
+        </a>
+      </div>
+    </section>
 </div>
 {% endblock %}

--- a/homepage/tests.py
+++ b/homepage/tests.py
@@ -1,3 +1,13 @@
 from django.test import TestCase
 
-# Create your tests here.
+
+class HomepageLayoutTests(TestCase):
+    def test_hall_of_fame_is_featured_above_oi_archive(self):
+        response = self.client.get('/')
+        self.assertEqual(response.status_code, 200)
+        content = response.content.decode()
+        self.assertIn('/67/hall-of-fame/', content)
+        self.assertIn('featured-hof', content)
+        self.assertIn('OI / competitive programming archive', content)
+        self.assertLess(content.index('featured-hof'), content.index('OI / competitive programming archive'))
+        self.assertLess(content.index('OI / competitive programming archive'), content.index('ORAC Leaderboards++'))


### PR DESCRIPTION
## What changed

- replace unconditional `response.json()` with guarded response parsing so HTML 403/413/500 responses show actionable errors
- keep exactly one run-control button visible: Enable Camera first, then I'm ready, then Restart
- reveal the live camera immediately after permission while detector setup finishes
- preload the MediaPipe module and pose model
- avoid Firefox's slow GPU-failure-then-CPU retry by selecting the CPU delegate directly
- prevent guest display names from colliding with registered usernames after NFKC/case normalisation
- reserve role-like names such as admin/staff/moderator and visibly suffix all anonymous names with `· guest`
- explain that guest deletion requests must be sent to the site owner with the public HOF URL
- feature Hall of Fame prominently on the homepage, 61/67 index and Counter toolbar
- move ORAC/OJ competitive-programming links into a lower homepage archive section
- refresh copy across the affected pages

## Root cause / diagnosis

The browser error `JSON.parse: unexpected character at line 1 column 1` means the upload response was HTML rather than JSON. The likely deployment-specific cause after PR #14 is an unapplied `brainrot.0003` migration producing an HTML HTTP 500 page. This patch makes that failure readable, but production must still run `python manage.py migrate`.

The camera pause was also plausibly amplified on Firefox by trying the MediaPipe GPU delegate first and then repeating model initialisation on CPU. Firefox now starts directly on CPU, while Chrome-family browsers retain GPU-first with CPU fallback.

## Validation

- `python manage.py check`
- `python manage.py makemigrations --check --dry-run` — no changes
- `python manage.py test brainrot homepage` — 25 passed
- `node --check brainrot/static/brainrot/counter.js`
- `python -m compileall -q brainrot homepage myblog`
- `git diff --check`

No new migration or dependency is introduced by this follow-up.