### PR TITLE
Improve 67 Hall of Fame copy and previews

### DIFF
--- a/brainrot/static/brainrot/brainrot.css
+++ b/brainrot/static/brainrot/brainrot.css
@@ -43,8 +43,6 @@
 .br-toolbar a { color: var(--br-ink); font-weight: 750; text-decoration: none; }
 .br-toolbar a:hover { color: var(--br-accent-dark); }
 .br-toolbar-links { display: flex; gap: 1rem; }
-.br-toolbar .hof-nav-link { padding: .28rem .6rem; border-radius: 999px; background: var(--br-ink); color: var(--br-lime); }
-.br-toolbar .hof-nav-link:hover { color: white; }
 
 .br-hero { max-width: 880px; padding: 3rem 0 4rem; }
 .br-hero h1, .counter-intro h1, .typing-heading h1, .hall-heading h1 {
@@ -102,7 +100,29 @@
   font-size: .92rem;
 }
 
-.counter-intro { max-width: 850px; }
+.counter-hero { display: grid; grid-template-columns: minmax(0, 1.35fr) minmax(310px, .65fr); align-items: stretch; gap: 1.25rem; }
+.counter-intro { display: flex; max-width: 850px; flex-direction: column; justify-content: center; }
+.counter-hof-column { display: flex; min-width: 0; flex-direction: column; }
+.counter-hof-portal {
+  display: flex;
+  min-height: 100%;
+  flex: 1;
+  flex-direction: column;
+  justify-content: center;
+  padding: 1.5rem;
+  overflow: hidden;
+  border-radius: 24px;
+  background: var(--br-ink);
+  color: white;
+  text-decoration: none;
+  box-shadow: 0 16px 40px rgba(15, 23, 42, .16);
+  transition: transform .18s ease, box-shadow .18s ease;
+}
+.counter-hof-portal:hover { color: white; transform: translateY(-3px); box-shadow: 0 22px 48px rgba(15, 23, 42, .22); }
+.counter-hof-portal > span { color: var(--br-lime); font-size: .68rem; font-weight: 850; letter-spacing: .12em; }
+.counter-hof-portal > strong { margin: .45rem 0 .65rem; font-size: clamp(2.6rem, 5vw, 4.8rem); font-weight: 950; line-height: .78; letter-spacing: -.07em; }
+.counter-hof-portal > small { color: #cbd5e1; font-size: .85rem; font-weight: 700; }
+.counter-my-hof { margin-top: .55rem; color: var(--br-ink); font-size: .82rem; font-weight: 800; text-align: right; }
 .counter-layout { display: grid; grid-template-columns: minmax(0, 1.55fr) minmax(290px, .65fr); gap: 1.25rem; }
 .challenge-layout { grid-template-columns: minmax(0, 2fr) minmax(250px, .55fr); }
 .duel-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 1rem; min-width: 0; }
@@ -255,14 +275,23 @@
 .hall-rank { color: var(--br-muted); font-weight: 800; }
 .hall-person { display: flex; flex-direction: column; }
 .hall-person span { color: var(--br-muted); font-size: .8rem; }
-.hall-score { font-size: 2rem; }
+.hall-score { display: flex; flex-direction: column; font-size: 2rem; line-height: .9; }
+.hall-score small { margin-top: .3rem; color: var(--br-muted); font-size: .62rem; font-weight: 750; letter-spacing: .06em; text-transform: uppercase; }
 .hall-actions { display: flex; justify-content: flex-end; gap: .85rem; }
 .hall-actions a { color: var(--br-accent-dark); font-size: .84rem; font-weight: 800; text-decoration: none; }
 .hall-actions form { margin: 0; }
 .hall-delete-link { padding: 0; border: 0; background: transparent; color: #b91c1c; font-size: .84rem; font-weight: 800; }
 .hall-delete-link:hover { text-decoration: underline; }
-.hall-entry summary { cursor: pointer; color: var(--br-accent-dark); font-size: .86rem; font-weight: 800; }
-.hall-entry video { width: min(420px, 75vw); max-height: 300px; margin-top: .7rem; border-radius: 10px; background: #111827; }
+.hall-preview { grid-column: 1 / -1; width: 100%; padding-top: .75rem; border-top: 1px dashed var(--br-line); }
+.hall-preview summary { width: fit-content; cursor: pointer; color: var(--br-accent-dark); font-size: .86rem; font-weight: 800; }
+.hall-preview summary::marker { color: var(--br-ink); }
+.hall-preview-body { display: grid; grid-template-columns: minmax(240px, 420px) minmax(220px, 1fr); align-items: center; gap: 1.2rem; padding: .8rem 0 .25rem; }
+.hall-preview video { width: 100%; max-height: 300px; border-radius: 10px; background: #111827; }
+.hall-preview-body > div { display: flex; align-items: flex-start; flex-direction: column; gap: .45rem; }
+.hall-preview-body > div > strong { font-size: 1.05rem; line-height: 1.35; }
+.hall-preview-body > div > span { max-width: 460px; color: var(--br-muted); font-size: .84rem; }
+.hall-preview-links { display: flex; flex-wrap: wrap; gap: .9rem; }
+.hall-preview-links a { color: var(--br-accent-dark); font-size: .86rem; font-weight: 800; }
 .hall-download { display: block; width: fit-content; margin: .45rem 0 0 auto; color: var(--br-ink); font-size: .8rem; font-weight: 750; }
 .empty-hall { padding: 4rem 1.5rem; text-align: center; }
 .empty-hall strong { font-size: 1.5rem; }
@@ -289,7 +318,7 @@
 .my-hall-entry { grid-template-columns: 65px 1fr 90px minmax(220px, .8fr); }
 
 @media (max-width: 780px) {
-  .br-game-grid, .counter-layout, .result-card, .hall-detail-grid { grid-template-columns: 1fr; }
+  .br-game-grid, .counter-hero, .counter-layout, .result-card, .hall-detail-grid { grid-template-columns: 1fr; }
   .duel-grid { grid-template-columns: 1fr; }
   .br-game-card { min-height: 300px; }
   .br-toolbar span { display: none; }
@@ -297,6 +326,7 @@
   .hall-entry { grid-template-columns: 45px 1fr 55px; }
   .my-hall-entry { grid-template-columns: 45px 1fr 55px; }
   .hall-actions { grid-column: 2 / -1; justify-content: flex-start; }
+  .hall-preview-body { grid-template-columns: 1fr; }
   .hall-detail-heading { align-items: start; flex-direction: column; gap: .6rem; }
   .hall-detail-heading .br-kicker { position: static; transform: none; }
   .typing-viewport { height: 205px; padding: 1.3rem; }

--- a/brainrot/static/brainrot/counter.js
+++ b/brainrot/static/brainrot/counter.js
@@ -156,15 +156,15 @@ if (app) {
 
   function shareableResult() {
     const headline = rivalName
-      ? `I scored ${score} against ${rivalName}'s ${rivalFinalScore} in a synchronised 67 Challenge. 🧪`
+      ? `I made ${score} 6️⃣7️⃣ moves in 20 seconds against ${rivalName}'s ${rivalFinalScore}.`
       : score === 67
-        ? 'I scored exactly 67 in the 67 Counter. Peer review is complete. 🧪'
-        : `I scored ${score} in the 67 Counter. The data is unfortunately real. 🧪`;
+        ? 'I made exactly 67 6️⃣7️⃣ moves in 20 seconds. Peer review is complete. 🧪'
+        : `I made ${score} 6️⃣7️⃣ moves in 20 seconds.`;
     const blocks = score > 0
       ? `${'🟩'.repeat(Math.min(score, 67))}${score > 67 ? ` +${score - 67}` : ''}`
       : '⬜';
     const url = rivalName ? window.location.href : new URL('/67/counter/', window.location.origin).href;
-    return `${headline}\n20 seconds of arm-based research\n${blocks}\nSIX SEVEN\nCan you do better?\n${url}`;
+    return `${headline}\n${blocks}\nSIX SEVEN\nWatch the run or try to beat it.\n${url}`;
   }
 
   async function copyShareResult() {

--- a/brainrot/static/brainrot/hof_detail.js
+++ b/brainrot/static/brainrot/hof_detail.js
@@ -5,7 +5,7 @@ if (detail) {
   const copyButton = document.getElementById('copy-hof-link');
   const status = document.getElementById('hof-share-status');
   const url = detail.dataset.entryUrl;
-  const text = `${detail.dataset.username} scored ${detail.dataset.score} in the 67 Hall of Fame.\nThe evidence has survived peer review by vibes.\n${url}`;
+  const text = `${detail.dataset.username} made ${detail.dataset.score} 6️⃣7️⃣ moves in 20 seconds.\nWatch the run and try to beat it:\n${url}`;
   shareText.value = text;
 
   async function copyLink() {

--- a/brainrot/templates/brainrot/counter.html
+++ b/brainrot/templates/brainrot/counter.html
@@ -8,7 +8,7 @@
 <link rel="preconnect" href="https://storage.googleapis.com" crossorigin>
 <link rel="modulepreload" href="https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@1.0.1/vision_bundle.mjs" crossorigin>
 <link rel="preload" href="https://storage.googleapis.com/mediapipe-models/pose_landmarker/pose_landmarker_lite/float16/1/pose_landmarker_lite.task" as="fetch" crossorigin>
-<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260814.8">
+<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260814.9">
 {% if turnstile_enabled %}<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>{% endif %}
 
 <main class="br-page counter-page" id="counter-app"
@@ -18,22 +18,30 @@
       {% if rival %}data-rival-name="{{ rival.public_name }}" data-rival-score="{{ rival.score }}"{% endif %}>
   <header class="br-toolbar">
     <a href="{% url 'brainrot:index' %}">← Research division</a>
-    <div class="br-toolbar-links">
-      {% if request.user.is_authenticated %}<a href="{% url 'brainrot:my_hall_of_fame' %}">My HOF</a>{% endif %}
-      <a class="hof-nav-link" href="{% url 'brainrot:hall_of_fame' %}">★ Hall of Fame</a>
-    </div>
   </header>
 
-  <section class="counter-intro">
-    {% if rival %}
-    <span class="br-kicker">SYNCHRONISED HUMAN PERFORMANCE TRIAL · 20 SECONDS</span>
-    <h1>YOU vs {{ rival.public_name }}</h1>
-    <p>The archived specimen will run beside you. Out-67 it under controlled laboratory conditions.</p>
-    {% else %}
-    <span class="br-kicker">POSE KINETICS LAB · 20 SECOND PROTOCOL</span>
-    <h1>SIX SEVEN</h1>
-    <p>Alternate your hands up and down. The Institute will count whatever happens next.</p>
-    {% endif %}
+  <section class="counter-hero">
+    <div class="counter-intro">
+      {% if rival %}
+      <span class="br-kicker">SYNCHRONISED HUMAN PERFORMANCE TRIAL · 20 SECONDS</span>
+      <h1>YOU vs {{ rival.public_name }}</h1>
+      <p>{{ rival.public_name }} made {{ rival.score }} 6️⃣7️⃣ moves in 20 seconds. Their video will play beside yours.</p>
+      {% else %}
+      <span class="br-kicker">POSE KINETICS LAB · 20 SECOND PROTOCOL</span>
+      <h1>SIX SEVEN</h1>
+      <p>Move your arms up and down in the 6–7 pattern. Make as many counted moves as you can in 20 seconds.</p>
+      {% endif %}
+    </div>
+    <div class="counter-hof-column">
+      <a class="counter-hof-portal" id="counter-hof-portal" href="{% url 'brainrot:hall_of_fame' %}">
+        <span>PUBLIC 20-SECOND VIDEO LEADERBOARD</span>
+        <strong>HALL OF<br>FAME</strong>
+        <small>Watch runs · preview videos · challenge scores →</small>
+      </a>
+      {% if request.user.is_authenticated %}
+      <a class="counter-my-hof" href="{% url 'brainrot:my_hall_of_fame' %}">Manage my submitted runs →</a>
+      {% endif %}
+    </div>
   </section>
 
   <section class="privacy-strip" aria-label="Camera privacy information">
@@ -79,13 +87,13 @@
 
     <aside class="counter-panel">
       <div class="score-block">
-        <span>observed 67 events</span>
+        <span>6️⃣7️⃣ moves counted</span>
         <strong id="score">0</strong>
       </div>
       <div class="timer-block"><span>time remaining</span><strong id="counter-time">20.0</strong></div>
       {% if rival %}
       <div class="challenge-target">
-        <span>target specimen</span>
+        <span>score to beat</span>
         <strong>{{ rival.score }}</strong>
         <a href="{% url 'brainrot:hall_of_fame_detail' rival.id %}">View HOF entry</a>
       </div>
@@ -102,7 +110,7 @@
   <section class="result-card" id="counter-result" hidden>
     <div>
       <span class="br-kicker">PEER-REVIEWED BY YOURSELF</span>
-      <h2><span id="result-score">0</span> confirmed-looking events</h2>
+      <h2><span id="result-score">0</span> 6️⃣7️⃣ moves in 20 seconds</h2>
       <p id="result-copy">A result has occurred.</p>
     </div>
     <div class="recording-review" id="recording-review" hidden>
@@ -147,5 +155,5 @@
 {% endif %}
 
 {# Keep this version in step with counter.js so browsers cannot retain a broken runtime URL. #}
-<script type="module" src="{% static 'brainrot/counter.js' %}?v=20260814.13"></script>
+<script type="module" src="{% static 'brainrot/counter.js' %}?v=20260814.14"></script>
 {% endblock %}

--- a/brainrot/templates/brainrot/hall_of_fame.html
+++ b/brainrot/templates/brainrot/hall_of_fame.html
@@ -4,7 +4,7 @@
 {% block title %}67 Hall of Fame{% endblock %}
 
 {% block content %}
-<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260814.8">
+<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260814.9">
 <main class="br-page hall-page">
   <header class="br-toolbar">
     <a href="{% url 'brainrot:counter' %}">← 67 Counter</a>
@@ -15,10 +15,10 @@
     {% endif %}
   </header>
   <section class="hall-heading">
-    <span class="br-kicker">PUBLIC ARCHIVE OF EXCEPTIONAL ARM ACTIVITY</span>
+    <span class="br-kicker">PUBLIC 20-SECOND VIDEO LEADERBOARD</span>
     <h1>67 Hall of Fame</h1>
-    <p>Valid uploads appear immediately. Guest names are visibly labelled and cannot copy registered usernames.
-      Obvious high-technology specimens may disappear without ceremony.</p>
+    <p>See who made the most 6️⃣7️⃣ moves in 20 seconds, watch each run, then challenge it yourself.
+      Guest names are visibly labelled and cannot copy registered usernames.</p>
   </section>
 
   <section class="hall-list">
@@ -27,13 +27,28 @@
       <span class="hall-rank">#{{ forloop.counter }}</span>
       <div class="hall-person">
         <strong>{{ entry.public_name }}</strong>
-        <span>{{ entry.created_at|date:'j M Y' }}</span>
+        <span>made {{ entry.score }} 6️⃣7️⃣ moves in 20 seconds · {{ entry.created_at|date:'j M Y' }}</span>
       </div>
-      <strong class="hall-score">{{ entry.score }}</strong>
+      <strong class="hall-score">{{ entry.score }}<small>moves</small></strong>
       <div class="hall-actions">
-        <a href="{% url 'brainrot:hall_of_fame_detail' entry.id %}">View specimen</a>
-        <a href="{% url 'brainrot:challenge' entry.id %}">Challenge</a>
+        <a href="{% url 'brainrot:hall_of_fame_detail' entry.id %}">Full details</a>
+        <a href="{% url 'brainrot:challenge' entry.id %}">Challenge this run</a>
       </div>
+      {% url 'brainrot:hall_of_fame_video' entry.id as preview_url %}
+      <details class="hall-preview">
+        <summary>Watch video preview</summary>
+        <div class="hall-preview-body">
+          <video controls preload="none" playsinline src="{{ preview_url }}"></video>
+          <div>
+            <strong>{{ entry.public_name }} made {{ entry.score }} 6️⃣7️⃣ moves in 20 seconds.</strong>
+            <span>Open the detail page to share this run, download it, or start a synchronized challenge.</span>
+            <div class="hall-preview-links">
+              <a href="{% url 'brainrot:hall_of_fame_detail' entry.id %}">Open full run →</a>
+              <a href="{{ preview_url }}?download=1">Download video</a>
+            </div>
+          </div>
+        </div>
+      </details>
     </article>
     {% empty %}
     <div class="empty-hall">

--- a/brainrot/templates/brainrot/hall_of_fame_detail.html
+++ b/brainrot/templates/brainrot/hall_of_fame_detail.html
@@ -4,7 +4,7 @@
 {% block title %}{{ entry.public_name }} — 67 Hall of Fame{% endblock %}
 
 {% block content %}
-<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260814.8">
+<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260814.9">
 <main class="br-page hall-detail-page" id="hof-detail"
       data-entry-url="{{ request.build_absolute_uri }}"
       data-username="{{ entry.public_name }}"
@@ -18,7 +18,7 @@
     <span class="br-kicker">ARCHIVED HUMAN PERFORMANCE SPECIMEN #{{ entry.id }}</span>
     <h1>{{ entry.score }}</h1>
     <div>
-      <strong>{{ entry.public_name }}</strong>
+      <strong>{{ entry.public_name }} made {{ entry.score }} 6️⃣7️⃣ moves in 20 seconds.</strong>
       <span>{{ entry.created_at|date:'j M Y · H:i' }} · {{ entry.duration_seconds|floatformat:2 }} seconds</span>
     </div>
   </section>
@@ -58,5 +58,5 @@
     </aside>
   </section>
 </main>
-<script src="{% static 'brainrot/hof_detail.js' %}?v=20260814.1" defer></script>
+<script src="{% static 'brainrot/hof_detail.js' %}?v=20260814.2" defer></script>
 {% endblock %}

--- a/brainrot/templates/brainrot/index.html
+++ b/brainrot/templates/brainrot/index.html
@@ -4,7 +4,7 @@
 {% block title %}Institute of 61/67 Studies{% endblock %}
 
 {% block content %}
-<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260814.8">
+<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260814.9">
 <main class="br-page">
   <section class="br-hero">
     <span class="br-kicker">ICAiJY INSTITUTE OF NUMERICAL CULTURE</span>
@@ -13,9 +13,9 @@
   </section>
   <a class="br-hof-banner" href="{% url 'brainrot:hall_of_fame' %}">
     <div>
-      <span class="br-kicker">PUBLIC VIDEO ARCHIVE</span>
+      <span class="br-kicker">PUBLIC 20-SECOND VIDEO LEADERBOARD</span>
       <h2>67 Hall of Fame</h2>
-      <p>Watch the evidence, share a specimen, or challenge somebody's recorded count.</p>
+      <p>Watch how many 6️⃣7️⃣ moves people made in 20 seconds, share a run, or challenge its score.</p>
     </div>
     <strong>Enter the archive →</strong>
   </a>

--- a/brainrot/tests.py
+++ b/brainrot/tests.py
@@ -28,8 +28,8 @@ class BrainrotPageTests(TestCase):
     @override_settings(DEBUG=True)
     def test_counter_uses_cache_busted_runtime_and_has_share_box(self):
         response = self.client.get('/67/counter/')
-        self.assertContains(response, 'brainrot.css?v=20260814.8')
-        self.assertContains(response, 'counter.js?v=20260814.13')
+        self.assertContains(response, 'brainrot.css?v=20260814.9')
+        self.assertContains(response, 'counter.js?v=20260814.14')
         self.assertContains(response, 'id="counter-share-text"')
         self.assertContains(response, 'id="copy-counter-share"')
         self.assertContains(response, 'id="download-recording"')
@@ -39,7 +39,9 @@ class BrainrotPageTests(TestCase):
         self.assertContains(response, 'id="submit-hof"')
         self.assertContains(response, 'id="hof-display-name"')
         self.assertContains(response, 'id="start-run" disabled hidden')
-        self.assertContains(response, '★ Hall of Fame')
+        self.assertContains(response, 'id="counter-hof-portal"')
+        self.assertContains(response, 'PUBLIC 20-SECOND VIDEO LEADERBOARD')
+        self.assertNotContains(response, 'hof-nav-link')
         self.assertNotContains(response, 'Log in to submit this run')
 
         script_path = finders.find('brainrot/counter.js')
@@ -66,6 +68,7 @@ class BrainrotPageTests(TestCase):
         self.assertNotIn('await response.json()', script)
         self.assertIn("const preferCpu = /Firefox\\//.test(navigator.userAgent);", script)
         self.assertIn("delegate: preferCpu ? 'CPU' : 'GPU'", script)
+        self.assertIn('I made ${score} 6️⃣7️⃣ moves in 20 seconds.', script)
         self.assertLess(script.index('enableButton.hidden = true;'), script.index('await initialisePoseRuntime();', script.index('async function initialiseDetector')))
 
 
@@ -88,11 +91,21 @@ class HallOfFamePageTests(TestCase):
         self.assertContains(response, 'id="hof-share-text"')
         self.assertContains(response, 'Share Hall of Fame link')
         self.assertContains(response, f'/67/challenge/{self.entry.id}/')
-        self.assertContains(response, 'hof_detail.js?v=20260814.1')
+        self.assertContains(response, 'swan-scientist made 3 6️⃣7️⃣ moves in 20 seconds.')
+        self.assertContains(response, 'hof_detail.js?v=20260814.2')
 
         leaderboard = self.client.get('/67/hall-of-fame/')
         self.assertContains(leaderboard, detail_path)
         self.assertContains(leaderboard, f'/67/challenge/{self.entry.id}/')
+        self.assertContains(leaderboard, 'Watch video preview')
+        self.assertContains(leaderboard, 'preload="none"')
+        self.assertContains(leaderboard, f'/67/hall-of-fame/{self.entry.id}/video/?download=1')
+        self.assertContains(leaderboard, 'swan-scientist made 3 6️⃣7️⃣ moves in 20 seconds.')
+
+        script_path = finders.find('brainrot/hof_detail.js')
+        self.assertIsNotNone(script_path)
+        script = Path(script_path).read_text(encoding='utf-8')
+        self.assertIn('made ${detail.dataset.score} 6️⃣7️⃣ moves in 20 seconds.', script)
 
     def test_challenge_embeds_video_and_exact_event_timeline(self):
         response = self.client.get(f'/67/challenge/{self.entry.id}/')

--- a/homepage/templates/homepage/index.html
+++ b/homepage/templates/homepage/index.html
@@ -155,7 +155,7 @@
 
     <div class="button-grid featured-grid">
         <a href="{% url 'brainrot:hall_of_fame' %}" class="nav-card btn-hof featured-hof">
-            ★ 67 Hall of Fame — watch, share, challenge
+            ★ 67 Hall of Fame — 20-second video leaderboard
         </a>
         <a href="{% url 'brainrot:index' %}" class="nav-card btn-brainrot">
             🧪 61/67 Research Division


### PR DESCRIPTION
## What changed

- rewrote Counter, challenge, Hall of Fame, detail and share copy around the clear result format: “NAME made SCORE 6️⃣7️⃣ moves in 20 seconds”
- removed Hall of Fame controls from the Counter’s upper-right toolbar
- added a large Hall of Fame portal beside the SIX SEVEN title, with My HOF management placed below it for signed-in users
- added an expandable video preview to every leaderboard row
- kept previews collapsed with `preload="none"` so opening the leaderboard does not eagerly load every video
- added full-detail and direct-download links inside each preview
- refreshed the 61/67 index and homepage labels to describe HOF as a 20-second video leaderboard
- bumped static cache keys and added regression assertions

## Why

The previous copy was funny but did not immediately explain the score, and the HOF links looked like secondary toolbar actions despite being a core feature. The leaderboard also required opening a detail page before users could inspect a run.

## Validation

- `node --check brainrot/static/brainrot/counter.js`
- `node --check brainrot/static/brainrot/hof_detail.js`
- `python3 -m compileall -q brainrot homepage`
- `git diff --check`

Django’s runtime checks could not be rerun in the isolated work container because Django is not installed there and dependency download is blocked. The change introduces no model, migration, route, package or server-side behavior changes.