### PR TITLE
Improve Hall of Fame share message

### DIFF
--- a/brainrot/static/brainrot/hof_detail.js
+++ b/brainrot/static/brainrot/hof_detail.js
@@ -5,31 +5,42 @@ if (detail) {
   const copyButton = document.getElementById('copy-hof-link');
   const status = document.getElementById('hof-share-status');
   const url = detail.dataset.entryUrl;
-  const text = `${detail.dataset.username} made ${detail.dataset.score} 6️⃣7️⃣ moves in 20 seconds.\nWatch the run and try to beat it:\n${url}`;
+  const score = Number(detail.dataset.score);
+  const blocks = score > 0
+    ? `${'🟩'.repeat(Math.min(score, 20))}${score > 20 ? ` +${score - 20}` : ''}`
+    : '⬜';
+  const text = `${detail.dataset.username} made ${score} 6️⃣7️⃣ moves in 20 seconds! 🔥\n${blocks}\nSIX SEVEN!\nWatch the run and try to beat it!\n${url}`;
   shareText.value = text;
 
-  async function copyLink() {
+  async function copyShareMessage() {
     try {
-      await navigator.clipboard.writeText(url);
-      status.textContent = 'Permanent specimen link copied.';
+      if (navigator.clipboard?.writeText && window.isSecureContext) {
+        await navigator.clipboard.writeText(text);
+      } else {
+        shareText.select();
+        shareText.setSelectionRange(0, shareText.value.length);
+        if (!document.execCommand('copy')) throw new Error('Copy command was rejected.');
+      }
+      copyButton.textContent = 'Copied! 🎉';
+      status.textContent = 'Full result copied! The 6️⃣7️⃣ evidence is ready for deployment.';
     } catch (error) {
       shareText.select();
-      document.execCommand('copy');
-      status.textContent = 'Share text copied.';
+      status.textContent = 'Automatic copy failed. Select the message and copy it manually.';
     }
+    window.setTimeout(() => { copyButton.textContent = 'Copy share message'; }, 1500);
   }
 
   shareButton.addEventListener('click', async () => {
     if (navigator.share) {
       try {
-        await navigator.share({ title: '67 Hall of Fame', text, url });
-        status.textContent = 'Evidence distributed.';
+        await navigator.share({ title: '67 Hall of Fame', text });
+        status.textContent = 'Result launched into the world! 🚀';
         return;
       } catch (error) {
         if (error.name === 'AbortError') return;
       }
     }
-    await copyLink();
+    await copyShareMessage();
   });
-  copyButton.addEventListener('click', copyLink);
+  copyButton.addEventListener('click', copyShareMessage);
 }

--- a/brainrot/templates/brainrot/hall_of_fame_detail.html
+++ b/brainrot/templates/brainrot/hall_of_fame_detail.html
@@ -44,9 +44,9 @@
       {% else %}
       <p>Distribute this evidence to researchers, rivals and confused relatives.</p>
       {% endif %}
-      <textarea id="hof-share-text" rows="5" readonly aria-label="Shareable Hall of Fame result"></textarea>
-      <button class="br-primary" id="share-hof" type="button">Share Hall of Fame link</button>
-      <button class="br-secondary" id="copy-hof-link" type="button">Copy link</button>
+      <textarea id="hof-share-text" rows="6" readonly aria-label="Shareable Hall of Fame result"></textarea>
+      <button class="br-primary" id="share-hof" type="button">Share result!</button>
+      <button class="br-secondary" id="copy-hof-link" type="button">Copy share message</button>
       {% if request.user == entry.user and entry.user_id %}
       <form class="hof-delete-form" method="post" action="{% url 'brainrot:delete_hall_of_fame_entry' entry.id %}"
             onsubmit="return confirm('Delete this Hall of Fame entry and its video permanently?');">
@@ -58,5 +58,5 @@
     </aside>
   </section>
 </main>
-<script src="{% static 'brainrot/hof_detail.js' %}?v=20260814.2" defer></script>
+<script src="{% static 'brainrot/hof_detail.js' %}?v=20260814.3" defer></script>
 {% endblock %}

--- a/brainrot/tests.py
+++ b/brainrot/tests.py
@@ -89,10 +89,11 @@ class HallOfFamePageTests(TestCase):
         detail_path = f'/67/hall-of-fame/{self.entry.id}/'
         response = self.client.get(detail_path)
         self.assertContains(response, 'id="hof-share-text"')
-        self.assertContains(response, 'Share Hall of Fame link')
+        self.assertContains(response, 'Share result!')
+        self.assertContains(response, 'Copy share message')
         self.assertContains(response, f'/67/challenge/{self.entry.id}/')
         self.assertContains(response, 'swan-scientist made 3 6️⃣7️⃣ moves in 20 seconds.')
-        self.assertContains(response, 'hof_detail.js?v=20260814.2')
+        self.assertContains(response, 'hof_detail.js?v=20260814.3')
 
         leaderboard = self.client.get('/67/hall-of-fame/')
         self.assertContains(leaderboard, detail_path)
@@ -105,7 +106,10 @@ class HallOfFamePageTests(TestCase):
         script_path = finders.find('brainrot/hof_detail.js')
         self.assertIsNotNone(script_path)
         script = Path(script_path).read_text(encoding='utf-8')
-        self.assertIn('made ${detail.dataset.score} 6️⃣7️⃣ moves in 20 seconds.', script)
+        self.assertIn('made ${score} 6️⃣7️⃣ moves in 20 seconds! 🔥', script)
+        self.assertIn("'🟩'.repeat(Math.min(score, 20))", script)
+        self.assertIn('copyShareMessage', script)
+        self.assertNotIn('navigator.clipboard.writeText(url)', script)
 
     def test_challenge_embeds_video_and_exact_event_timeline(self):
         response = self.client.get(f'/67/challenge/{self.entry.id}/')


### PR DESCRIPTION
## What changed

- split the two Hall of Fame share actions into a real system-share button and a copy-full-message button
- replace the plain result sentence with a Wordle-style share card containing the player, score, 20-second duration, green score blocks, an excited challenge line and the permanent run URL
- make unsupported Web Share API browsers fall back to copying the full message instead of copying only the URL
- add clearer success and failure feedback
- bump the HOF detail script cache key and update regression assertions

## Validation

- `node --check brainrot/static/brainrot/hof_detail.js`
- `python3 -m compileall -q brainrot`
- `git diff --check`

No migration, dependency, route or server-side behaviour change.