### PR TITLE
Use content-hashed static asset URLs

### DIFF
--- a/myblog/settings.py
+++ b/myblog/settings.py
@@ -142,6 +142,15 @@ STATIC_URL = '/static/'
 STATICFILES_DIRS = [os.path.join(BASE_DIR, 'static')]
 STATIC_ROOT = os.path.join(BASE_DIR, 'staticfiles')
 
+STORAGES = {
+    'default': {
+        'BACKEND': 'django.core.files.storage.FileSystemStorage',
+    },
+    'staticfiles': {
+        'BACKEND': 'myblog.static_storage.HashedManifestStaticFilesStorage',
+    },
+}
+
 # Retained as a feature flag so the OJ can be restored without resurrecting
 # public submission endpoints by accident.
 OJ_ENABLED = os.getenv('OJ_ENABLED', 'False') == 'True'

--- a/myblog/static_storage.py
+++ b/myblog/static_storage.py
@@ -1,0 +1,7 @@
+from django.contrib.staticfiles.storage import ManifestStaticFilesStorage
+
+
+class HashedManifestStaticFilesStorage(ManifestStaticFilesStorage):
+    """Static storage with content hashes, including ES module imports."""
+
+    support_js_module_import_aggregation = True


### PR DESCRIPTION
## What changed
- switch Django staticfiles to a manifest-backed storage so production `{% static %}` URLs include a content hash
- enable Django 5.2's ES-module import rewriting so `counter.js` also points at the hashed `gesture_engine.js`

## Why
`collectstatic` updates `STATIC_ROOT`, but it does not change the URL requested by browsers/proxies/CDNs when assets are named `/static/foo.js`. A content hash makes each changed asset a new URL, so deployments no longer need manual `?v=...` bumps.

The existing query-string versions can stay for now; the filename itself will change when content changes, so they no longer need to be updated manually.

## Deploy
Run:

```sh
python manage.py collectstatic --noinput
```

Production must run with `DEBUG=False` for manifest URLs to be emitted.

## Validation
Compared the branch against `main`: only `myblog/settings.py` and the new `myblog/static_storage.py` are changed. Local test execution was not available in this environment, so deployment should run the existing Django checks/tests before merge/deploy.