### PR TITLE
Polish Tung Tung counter UI and detection

### DIFF
--- a/brainrot/js_tests/gesture_engine.test.mjs
+++ b/brainrot/js_tests/gesture_engine.test.mjs
@@ -25,14 +25,14 @@ function sixSevenPose(leftWristY, rightWristY) {
   return pose;
 }
 
-function legPose(kneeGap, { ankleShift = 0, hipShift = 0 } = {}) {
+function legPose(kneeGap, { ankleVisible = true } = {}) {
   const pose = blankPose();
-  pose[23] = { x: 0.40 + hipShift, y: 0.46, visibility: 1 };
-  pose[24] = { x: 0.60 + hipShift, y: 0.46, visibility: 1 };
+  pose[23] = { x: 0.40, y: 0.46, visibility: 1 };
+  pose[24] = { x: 0.60, y: 0.46, visibility: 1 };
   pose[25] = { x: 0.50 - kneeGap / 2, y: 0.66, visibility: 1 };
   pose[26] = { x: 0.50 + kneeGap / 2, y: 0.66, visibility: 1 };
-  pose[27] = { x: 0.30 + ankleShift, y: 0.90, visibility: 1 };
-  pose[28] = { x: 0.70 + ankleShift, y: 0.90, visibility: 1 };
+  pose[27] = { x: 0.30, y: 0.90, visibility: ankleVisible ? 1 : 0 };
+  pose[28] = { x: 0.70, y: 0.90, visibility: ankleVisible ? 1 : 0 };
   return pose;
 }
 
@@ -43,30 +43,54 @@ test('the existing 67 direction-change rule is preserved', () => {
   assert.equal(tracker.observe(sixSevenPose(0.70, 0.30), 400), true);
 });
 
-test('a leg clap requires open, inward, then open before another count', () => {
+test('a leg clap counts close once and requires a clear reopen before re-arming', () => {
   const tracker = createGestureTracker(GAME_MODES.LEG_CLAPS);
-  for (const time of [100, 133, 166]) assert.equal(tracker.observe(legPose(0.36), time), false);
-  assert.equal(tracker.observe(legPose(0.16), 220), false);
-  assert.equal(tracker.observe(legPose(0.12), 253), true);
-  assert.equal(tracker.observe(legPose(0.10), 300), false);
-  assert.equal(tracker.observe(legPose(0.12), 360), false);
 
-  for (const time of [420, 453, 486]) assert.equal(tracker.observe(legPose(0.36), time), false);
-  assert.equal(tracker.observe(legPose(0.14), 540), false);
-  assert.equal(tracker.observe(legPose(0.10), 573), true);
+  // hip width is .20, so .14 knee gap = .70 (open) and .07 = .35 (closed).
+  assert.equal(tracker.observe(legPose(0.14), 100), false);
+  assert.equal(tracker.observe(legPose(0.14), 133), false);
+  assert.equal(tracker.observe(legPose(0.07), 200), false);
+  assert.equal(tracker.observe(legPose(0.07), 233), true);
+
+  // Staying closed cannot farm counts.
+  assert.equal(tracker.observe(legPose(0.06), 266), false);
+  assert.equal(tracker.observe(legPose(0.07), 299), false);
+
+  // A partial opening inside the hysteresis band is not enough.
+  assert.equal(tracker.observe(legPose(0.11), 332), false);
+  assert.equal(tracker.observe(legPose(0.07), 365), false);
+
+  // Reopen for two frames, then another close can count.
+  assert.equal(tracker.observe(legPose(0.14), 400), false);
+  assert.equal(tracker.observe(legPose(0.14), 433), false);
+  assert.equal(tracker.observe(legPose(0.07), 466), false);
+  assert.equal(tracker.observe(legPose(0.07), 499), true);
 });
 
-test('starting closed does not count and unstable feet invalidate the cycle', () => {
+test('starting closed never counts until an open pose has armed the tracker', () => {
   const tracker = createGestureTracker(GAME_MODES.LEG_CLAPS);
-  assert.equal(tracker.observe(legPose(0.10), 200), false);
-  assert.equal(tracker.observe(legPose(0.10), 240), false);
-  for (const time of [300, 333, 366]) assert.equal(tracker.observe(legPose(0.36), time), false);
-  assert.equal(tracker.observe(legPose(0.12, { ankleShift: 0.20 }), 420), false);
-  assert.equal(tracker.observe(legPose(0.10, { ankleShift: 0.20 }), 453), false);
+  assert.equal(tracker.observe(legPose(0.06), 100), false);
+  assert.equal(tracker.observe(legPose(0.06), 133), false);
+  assert.equal(tracker.observe(legPose(0.14), 166), false);
+  assert.equal(tracker.observe(legPose(0.14), 199), false);
+  assert.equal(tracker.observe(legPose(0.07), 232), false);
+  assert.equal(tracker.observe(legPose(0.07), 265), true);
 });
 
-test('leg-clap readiness requires hips, knees and ankles', () => {
-  const pose = legPose(0.36);
+test('leg-clap readiness only requires hips and knees, not feet', () => {
+  const pose = legPose(0.14, { ankleVisible: false });
+  assert.equal(landmarksAreVisible(GAME_MODES.LEG_CLAPS, pose), true);
   pose[25].visibility = 0.1;
   assert.equal(landmarksAreVisible(GAME_MODES.LEG_CLAPS, pose), false);
+});
+
+test('losing knee tracking disarms the current leg-clap cycle', () => {
+  const tracker = createGestureTracker(GAME_MODES.LEG_CLAPS);
+  assert.equal(tracker.observe(legPose(0.14), 100), false);
+  assert.equal(tracker.observe(legPose(0.14), 133), false);
+  const lost = legPose(0.07);
+  lost[25].visibility = 0.1;
+  assert.equal(tracker.observe(lost, 166), false);
+  assert.equal(tracker.observe(legPose(0.07), 199), false);
+  assert.equal(tracker.observe(legPose(0.07), 232), false);
 });

--- a/brainrot/static/brainrot/counter.js
+++ b/brainrot/static/brainrot/counter.js
@@ -3,7 +3,7 @@ import {
   OVERLAY_GEOMETRY,
   createGestureTracker,
   landmarksAreVisible,
-} from './gesture_engine.js?v=20260817.2';
+} from './gesture_engine.js';
 
 const app = document.getElementById('counter-app');
 if (app) {
@@ -121,8 +121,6 @@ if (app) {
       runtimePromise = (async () => {
         const { FilesetResolver, PoseLandmarker, wasmRoot } = await loadMediaPipe();
         const vision = await FilesetResolver.forVisionTasks(wasmRoot);
-        // Firefox can spend several seconds failing the GPU delegate before
-        // repeating the same initialisation on CPU. Start on CPU there.
         const preferCpu = /Firefox\//.test(navigator.userAgent);
         const options = {
           baseOptions: {
@@ -192,14 +190,14 @@ if (app) {
       resultUnit: modeNode(prefix, 'result-unit'),
       mark: modeNode(prefix, 'placeholder'),
       hudLabel: mode === GAME_MODES.LEG_CLAPS ? 'LEG CLAPS' : '67 COUNT',
-      hudBrand: mode === GAME_MODES.LEG_CLAPS ? 'ICAiJY · TUNG TUNG' : 'ICAiJY · SIX SEVEN',
+      hudBrand: 'icaijy.com',
       downloadSlug: mode === GAME_MODES.LEG_CLAPS ? 'tung-tung-leg-claps' : '67-run',
     };
   }
 
   function armedStatus() {
     return currentMode === GAME_MODES.LEG_CLAPS
-      ? tr('Armed — keep hips, knees and ankles visible')
+      ? tr('Detector ready — step into frame')
       : tr('Armed — step back until shoulders and wrists are visible');
   }
 
@@ -332,9 +330,6 @@ if (app) {
   }
 
   function observeGesture(landmarks, now) {
-    // The detector and timer use separate animation-frame loops. Enforce the
-    // deadline here too so a detector frame cannot sneak in after 20 seconds
-    // but before the timer loop has rendered the finished state.
     if (!running || now >= endTime || !sufficientlyVisible(landmarks)) return;
     if (gestureTracker.observe(landmarks, now)) {
       score += 1;
@@ -368,7 +363,6 @@ if (app) {
             startButton.textContent = READY_LABEL;
             setStatus(tr("Pose detected — click I'm ready, then take your position"), 'ready');
           } else {
-            // Readiness is a user decision; a pose is required to start, not to arm the run.
             startButton.disabled = false;
             startButton.textContent = READY_LABEL;
             setStatus(tr("Detector ready — click I'm ready, then step into frame"), 'ready');
@@ -425,9 +419,6 @@ if (app) {
     const type = preferredRecordingType();
     if (!type) throw new Error('This browser cannot record a compatible WebM/MP4 video.');
 
-    // Firefox can preserve the age of a long-lived camera track in WebM packet
-    // timestamps. A canvas capture creates a fresh recording clock without
-    // requesting the camera again or changing the stream used by MediaPipe.
     recordingCanvas = document.createElement('canvas');
     recordingCanvas.width = video.videoWidth || 640;
     recordingCanvas.height = video.videoHeight || 480;
@@ -437,7 +428,6 @@ if (app) {
       recordingContext = null;
       throw new Error('This browser cannot create a timestamp-safe recording.');
     }
-
     const drawRecordingFrame = () => {
       if (!recordingContext || !recordingCanvas) return;
       recordingContext.drawImage(video, 0, 0, recordingCanvas.width, recordingCanvas.height);
@@ -688,7 +678,7 @@ if (app) {
     recordingDownload.removeAttribute('href');
     recordingDownload.hidden = true;
     recordingReview.hidden = true;
-      if (uploadStatus) uploadStatus.textContent = tr('Recording discarded. Nothing was uploaded.');
+    if (uploadStatus) uploadStatus.textContent = tr('Recording discarded. Nothing was uploaded.');
   }
 
   function resetRun() {

--- a/brainrot/static/brainrot/counter_bootstrap.css
+++ b/brainrot/static/brainrot/counter_bootstrap.css
@@ -1,0 +1,266 @@
+/* Counter-specific layout on top of the site's existing Bootstrap shell. */
+.counter-page [hidden],
+.publication-modal[hidden] {
+  display: none !important;
+}
+
+.counter-page {
+  max-width: 1140px;
+}
+
+.counter-page .counter-heading {
+  max-width: 760px;
+}
+
+.counter-page .counter-heading h1 {
+  font-family: Arial, sans-serif;
+  font-weight: 700;
+  letter-spacing: -.03em;
+}
+
+.counter-page .mode-badge {
+  font-size: .78rem;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+.counter-page .camera-card,
+.counter-page .score-card,
+.counter-page .result-card,
+.counter-page .hof-card {
+  border: 1px solid var(--bs-border-color);
+  border-radius: .75rem;
+  background: var(--bs-body-bg);
+  box-shadow: 0 .125rem .25rem rgba(0, 0, 0, .075);
+}
+
+.camera-stage {
+  position: relative;
+  overflow: hidden;
+  aspect-ratio: 4 / 3;
+  border-radius: .7rem .7rem 0 0;
+  background: #111827;
+}
+
+.camera-stage video,
+.camera-stage canvas {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  transform: scaleX(-1);
+}
+
+.camera-stage canvas {
+  pointer-events: none;
+}
+
+.rival-stage video {
+  transform: none;
+}
+
+.camera-placeholder {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-content: center;
+  gap: .75rem;
+  padding: 1.5rem;
+  color: #adb5bd;
+  text-align: center;
+}
+
+.counter-placeholder-mark {
+  display: grid;
+  width: 84px;
+  height: 84px;
+  margin: 0 auto;
+  place-items: center;
+  border: 2px solid #6c757d;
+  border-radius: 50%;
+  color: #fff;
+  font: 700 2rem/1 Arial, sans-serif;
+}
+
+.countdown {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  color: #fff;
+  font: 700 clamp(5rem, 18vw, 10rem)/1 Arial, sans-serif;
+  text-shadow: 0 .25rem 1rem rgba(0, 0, 0, .55);
+  pointer-events: none;
+}
+
+.live-pill {
+  position: absolute;
+  top: .75rem;
+  left: .75rem;
+  padding: .35rem .6rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, .94);
+  color: #dc3545;
+  font: 700 .72rem/1.2 Arial, sans-serif;
+}
+
+.rival-score-pill {
+  position: absolute;
+  right: .75rem;
+  bottom: .75rem;
+  display: flex;
+  align-items: center;
+  gap: .6rem;
+  padding: .4rem .6rem;
+  border-radius: .5rem;
+  background: rgba(33, 37, 41, .84);
+  color: #fff;
+}
+
+.rival-score-pill strong {
+  font: 700 1.6rem/1 Arial, sans-serif;
+}
+
+.detector-status {
+  display: flex;
+  align-items: center;
+  gap: .6rem;
+  min-height: 46px;
+  padding: .7rem .9rem;
+  border-top: 1px solid var(--bs-border-color);
+  color: var(--bs-secondary-color);
+  font-size: .875rem;
+}
+
+.status-dot {
+  flex: 0 0 auto;
+  width: .6rem;
+  height: .6rem;
+  border-radius: 50%;
+  background: #adb5bd;
+}
+
+.detector-status.ready .status-dot { background: #198754; }
+.detector-status.busy .status-dot { background: #ffc107; }
+
+.score-value {
+  font: 700 clamp(4rem, 10vw, 6.5rem)/.95 Arial, sans-serif;
+  letter-spacing: -.05em;
+}
+
+.timer-value {
+  font: 700 2rem/1 Arial, sans-serif;
+}
+
+.hof-mark {
+  min-width: 58px;
+  color: var(--bs-primary);
+  font: 700 2.5rem/1 Arial, sans-serif;
+  text-align: center;
+}
+
+.counter-page .btn {
+  font-family: Arial, sans-serif;
+  font-weight: 600;
+}
+
+.counter-error {
+  min-height: 1.5rem;
+}
+
+.recording-review video,
+.hall-evidence-card video {
+  width: 100%;
+  max-height: 520px;
+  border-radius: .5rem;
+  background: #111827;
+}
+
+.counter-share textarea {
+  width: 100%;
+  resize: vertical;
+}
+
+.anonymous-name-field {
+  display: block;
+}
+
+.anonymous-name-field input {
+  width: 100%;
+}
+
+.publication-modal {
+  position: fixed;
+  z-index: 1080;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  padding: 1rem;
+}
+
+.publication-modal-backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(0, 0, 0, .55);
+}
+
+.publication-modal-card {
+  position: relative;
+  z-index: 1;
+  width: min(540px, 100%);
+  padding: 1.5rem;
+  border-radius: .75rem;
+  background: #fff;
+  box-shadow: 0 1rem 3rem rgba(0, 0, 0, .3);
+}
+
+.publication-modal-close {
+  position: absolute;
+  top: .75rem;
+  right: .75rem;
+  border: 0;
+  background: transparent;
+  color: #6c757d;
+  font-size: 1.75rem;
+  line-height: 1;
+}
+
+.publication-consent-check {
+  display: flex;
+  gap: .65rem;
+  align-items: flex-start;
+  margin: 1rem 0;
+}
+
+.publication-modal-actions {
+  display: flex;
+  gap: .5rem;
+  justify-content: flex-end;
+}
+
+body.publication-modal-open {
+  overflow: hidden;
+}
+
+@media (max-width: 767.98px) {
+  .counter-page {
+    padding-top: 1.5rem !important;
+  }
+
+  .counter-page .counter-heading h1 {
+    font-size: 2.25rem;
+  }
+
+  .score-value {
+    font-size: 4.5rem;
+  }
+
+  .publication-modal-actions {
+    flex-direction: column-reverse;
+  }
+
+  .publication-modal-actions .btn {
+    width: 100%;
+  }
+}

--- a/brainrot/static/brainrot/gesture_engine.js
+++ b/brainrot/static/brainrot/gesture_engine.js
@@ -5,7 +5,10 @@ export const GAME_MODES = Object.freeze({
 
 const LANDMARK_SETS = Object.freeze({
   [GAME_MODES.SIX_SEVEN]: [11, 12, 15, 16],
-  [GAME_MODES.LEG_CLAPS]: [23, 24, 25, 26, 27, 28],
+  // Leg claps are defined by the knees. Ankles are deliberately not required:
+  // MediaPipe often loses feet near the bottom of a phone frame, and foot motion
+  // should not decide whether an inward knee clap happened.
+  [GAME_MODES.LEG_CLAPS]: [23, 24, 25, 26],
 });
 
 export const OVERLAY_GEOMETRY = Object.freeze({
@@ -14,8 +17,8 @@ export const OVERLAY_GEOMETRY = Object.freeze({
     links: [[11, 13], [13, 15], [12, 14], [14, 16], [11, 12], [15, 16]],
   },
   [GAME_MODES.LEG_CLAPS]: {
-    points: [23, 24, 25, 26, 27, 28],
-    links: [[23, 24], [23, 25], [25, 27], [24, 26], [26, 28], [25, 26], [27, 28]],
+    points: [23, 24, 25, 26],
+    links: [[23, 24], [23, 25], [24, 26], [25, 26]],
   },
 });
 
@@ -67,13 +70,12 @@ class SixSevenTracker {
   }
 }
 
-function midpoint(a, b) {
-  return { x: (a.x + b.x) / 2, y: (a.y + b.y) / 2 };
-}
-
-function distance(a, b) {
-  return Math.hypot(a.x - b.x, a.y - b.y);
-}
+// These are intentionally boring, easy-to-tune thresholds rather than an
+// attempt to infer whether feet/hips stayed perfectly fixed. kneeRatio is the
+// horizontal knee gap divided by horizontal hip width.
+const LEG_CLAP_CLOSE_RATIO = 0.42;
+const LEG_CLAP_REOPEN_RATIO = 0.62;
+const LEG_CLAP_STABLE_FRAMES = 2;
 
 class LegClapTracker {
   constructor() {
@@ -81,82 +83,55 @@ class LegClapTracker {
   }
 
   reset() {
+    this.armed = false;
     this.openFrames = 0;
     this.closedFrames = 0;
-    this.readyForClose = false;
-    this.openBaseline = null;
-    this.lastCountAt = 0;
   }
 
-  metrics(landmarks) {
+  kneeRatio(landmarks) {
     const leftHip = landmarks[23];
     const rightHip = landmarks[24];
     const leftKnee = landmarks[25];
     const rightKnee = landmarks[26];
-    const leftAnkle = landmarks[27];
-    const rightAnkle = landmarks[28];
-    const ankleGap = Math.abs(leftAnkle.x - rightAnkle.x);
-    const hipGap = Math.abs(leftHip.x - rightHip.x);
-    const scale = Math.max(ankleGap, hipGap, 0.08);
-    return {
-      kneeRatio: Math.abs(leftKnee.x - rightKnee.x) / scale,
-      scale,
-      leftAnkle,
-      rightAnkle,
-      hipCentre: midpoint(leftHip, rightHip),
-    };
+    const hipWidth = Math.max(Math.abs(leftHip.x - rightHip.x), 0.06);
+    return Math.abs(leftKnee.x - rightKnee.x) / hipWidth;
   }
 
-  stableSinceOpen(metrics) {
-    if (!this.openBaseline) return false;
-    const ankleTolerance = metrics.scale * 0.28;
-    const hipTolerance = metrics.scale * 0.30;
-    return distance(metrics.leftAnkle, this.openBaseline.leftAnkle) <= ankleTolerance
-      && distance(metrics.rightAnkle, this.openBaseline.rightAnkle) <= ankleTolerance
-      && distance(metrics.hipCentre, this.openBaseline.hipCentre) <= hipTolerance;
-  }
-
-  observe(landmarks, now) {
+  observe(landmarks) {
     if (!landmarksAreVisible(GAME_MODES.LEG_CLAPS, landmarks)) {
-      this.openFrames = Math.max(0, this.openFrames - 1);
+      this.openFrames = 0;
       this.closedFrames = 0;
+      // Require a fresh visible open pose after tracking is lost. This avoids
+      // counting a person merely re-entering the frame with their knees closed.
+      this.armed = false;
       return false;
     }
 
-    const metrics = this.metrics(landmarks);
-    if (metrics.kneeRatio >= 0.72) {
-      this.openFrames += 1;
+    const ratio = this.kneeRatio(landmarks);
+
+    if (ratio >= LEG_CLAP_REOPEN_RATIO) {
       this.closedFrames = 0;
-      if (this.openFrames >= 3) {
-        this.readyForClose = true;
-        this.openBaseline = {
-          leftAnkle: { ...metrics.leftAnkle },
-          rightAnkle: { ...metrics.rightAnkle },
-          hipCentre: { ...metrics.hipCentre },
-        };
-      }
+      this.openFrames += 1;
+      if (this.openFrames >= LEG_CLAP_STABLE_FRAMES) this.armed = true;
       return false;
     }
 
     this.openFrames = 0;
-    if (metrics.kneeRatio > 0.45) {
+    if (ratio > LEG_CLAP_CLOSE_RATIO) {
       this.closedFrames = 0;
       return false;
     }
-    if (!this.readyForClose) return false;
+
+    if (!this.armed) {
+      this.closedFrames = 0;
+      return false;
+    }
 
     this.closedFrames += 1;
-    if (this.closedFrames < 2) return false;
-    if (!this.stableSinceOpen(metrics)) {
-      this.readyForClose = false;
-      this.closedFrames = 0;
-      return false;
-    }
-    if (now - this.lastCountAt <= 120) return false;
+    if (this.closedFrames < LEG_CLAP_STABLE_FRAMES) return false;
 
-    this.readyForClose = false;
+    this.armed = false;
     this.closedFrames = 0;
-    this.lastCountAt = now;
     return true;
   }
 }

--- a/brainrot/templates/brainrot/_entry_controls.html
+++ b/brainrot/templates/brainrot/_entry_controls.html
@@ -1,8 +1,8 @@
 {% load i18n %}
 {% if request.user.is_authenticated %}
   {% if request.user.is_superuser or entry.user_id == request.user.id %}
-  <div class="hof-management">
-    <span class="visibility-badge visibility-{{ entry.visibility }}">
+  <div class="d-flex flex-wrap align-items-center gap-2 mt-2">
+    <span class="badge {% if entry.visibility == 'public' %}text-bg-success{% else %}text-bg-secondary{% endif %}">
       {% if entry.visibility == 'public' %}{% translate "Public" %}{% else %}{% translate "Private" %}{% endif %}
     </span>
     <form method="post" action="{% url 'brainrot:set_hall_of_fame_visibility' entry.id %}">
@@ -10,10 +10,10 @@
       <input type="hidden" name="next" value="{{ request.get_full_path }}">
       {% if entry.visibility == 'public' %}
       <input type="hidden" name="visibility" value="private">
-      <button class="hall-manage-button" type="submit">{% translate "Make private" %}</button>
+      <button class="btn btn-sm btn-outline-secondary" type="submit">{% translate "Make private" %}</button>
       {% else %}
       <input type="hidden" name="visibility" value="public">
-      <button class="hall-manage-button" type="submit">{% translate "Publish" %}</button>
+      <button class="btn btn-sm btn-outline-success" type="submit">{% translate "Publish" %}</button>
       {% endif %}
     </form>
     {% translate "Delete this Hall of Fame entry and its video permanently?" as delete_confirmation %}
@@ -21,7 +21,7 @@
           onsubmit="return confirm('{{ delete_confirmation|escapejs }}');">
       {% csrf_token %}
       <input type="hidden" name="next" value="{% url 'brainrot:my_hall_of_fame' %}?deleted=1">
-      <button class="hall-delete-link" type="submit">{% translate "Delete" %}</button>
+      <button class="btn btn-sm btn-outline-danger" type="submit">{% translate "Delete" %}</button>
     </form>
   </div>
   {% endif %}

--- a/brainrot/templates/brainrot/counter.html
+++ b/brainrot/templates/brainrot/counter.html
@@ -8,23 +8,20 @@
 <link rel="preconnect" href="https://storage.googleapis.com" crossorigin>
 <link rel="modulepreload" href="https://cdn.jsdelivr.net/npm/@mediapipe/tasks-vision@1.0.1/vision_bundle.mjs" crossorigin>
 <link rel="preload" href="https://storage.googleapis.com/mediapipe-models/pose_landmarker/pose_landmarker_lite/float16/1/pose_landmarker_lite.task" as="fetch" crossorigin>
-<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260817.2">
+<link rel="stylesheet" href="{% static 'brainrot/counter_bootstrap.css' %}">
 {% if turnstile_enabled %}<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>{% endif %}
 
-<main class="br-page counter-page" id="counter-app"
+<main class="container py-4 py-md-5 counter-page" id="counter-app"
       data-submit-url="{% url 'brainrot:submit_hall_of_fame' %}"
       data-hall-url="{% url 'brainrot:hall_of_fame' %}"
       data-max-upload-mb="{{ max_upload_mb }}"
       data-game-mode="{{ game_mode }}"
       data-mode-locked="{% if rival %}true{% else %}false{% endif %}"
       {% if rival %}data-rival-name="{{ rival.public_name }}" data-rival-score="{{ rival.score }}"{% endif %}>
-  <header class="br-toolbar">
-    <a href="{% url 'brainrot:index' %}">← {% translate "Research division" %}</a>
-  </header>
 
   <div class="counter-mode-copy" hidden>
-    <span id="six-seven-title">SIX SEVEN</span>
-    <span id="leg-claps-title">{% translate "TUNG TUNG LEG CLAPS" %}</span>
+    <span id="six-seven-title">67 Counter</span>
+    <span id="leg-claps-title">{% translate "Tung Tung Leg Claps" %}</span>
     <span id="six-seven-description">{% translate "Move your arms up and down in the 6–7 pattern. Make as many counted moves as you can in 20 seconds." %}</span>
     <span id="leg-claps-description">{% translate "Count each time Tung Tung's knees swing inward from a clearly open position. The knees must open again before another clap." %}</span>
     <span id="six-seven-score-label">{% translate "6️⃣7️⃣ moves counted" %}</span>
@@ -35,145 +32,165 @@
     <span id="leg-claps-placeholder">TT</span>
   </div>
 
-  {% if not rival %}
-  <nav class="counter-mode-switcher" aria-label="{% translate 'Counter mode' %}">
-    <button type="button" data-counter-mode="six_seven" class="{% if game_mode == 'six_seven' %}active{% endif %}">
-      <strong>67 Counter</strong>
-      <small>{% translate "arm pattern" %}</small>
-    </button>
-    <button type="button" data-counter-mode="leg_claps" class="{% if game_mode == 'leg_claps' %}active{% endif %}">
-      <strong>{% translate "Tung Tung Leg Claps" %}</strong>
-      <small>{% translate "酸黄瓜舞计数" %}</small>
-    </button>
-  </nav>
-  {% else %}
-  <div class="counter-mode-locked">{% translate "Challenge mode:" %} <strong>{{ rival.get_game_mode_display }}</strong></div>
-  {% endif %}
+  <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-4">
+    <a class="btn btn-sm btn-outline-secondary" href="{% url 'brainrot:index' %}">← {% translate "Research division" %}</a>
+    <a class="btn btn-sm btn-outline-dark" href="{% url 'brainrot:hall_of_fame' %}?mode={{ game_mode }}">
+      <i class="fa-solid fa-ranking-star me-1"></i> {% translate "Hall of Fame" %}
+    </a>
+  </div>
 
-  <section class="counter-hero">
-    <div class="counter-intro">
-      {% if rival %}
-      <span class="br-kicker">{% translate "SYNCHRONISED HUMAN PERFORMANCE TRIAL · 20 SECONDS" %}</span>
-      <h1>YOU vs {{ rival.public_name }}</h1>
-      <p>{% if game_mode == 'leg_claps' %}{% blocktranslate with name=rival.public_name score=rival.score %}{{ name }} made {{ score }} Tung Tung Leg Claps in 20 seconds. Their video will play beside yours.{% endblocktranslate %}{% else %}{% blocktranslate with name=rival.public_name score=rival.score %}{{ name }} made {{ score }} 6️⃣7️⃣ moves in 20 seconds. Their video will play beside yours.{% endblocktranslate %}{% endif %}</p>
-      {% else %}
-      <span class="br-kicker">{% translate "POSE KINETICS LAB · 20 SECOND PROTOCOL" %}</span>
-      <h1 id="counter-title">{% if game_mode == 'leg_claps' %}{% translate "TUNG TUNG LEG CLAPS" %}{% else %}SIX SEVEN{% endif %}</h1>
-      <p id="counter-description">{% if game_mode == 'leg_claps' %}{% translate "Count each time Tung Tung's knees swing inward from a clearly open position. The knees must open again before another clap." %}{% else %}{% translate "Move your arms up and down in the 6–7 pattern. Make as many counted moves as you can in 20 seconds." %}{% endif %}</p>
-      {% endif %}
+  <header class="counter-heading mb-4">
+    {% if rival %}
+      <span class="badge text-bg-dark mode-badge mb-2">{% translate "Challenge mode:" %} {{ rival.get_game_mode_display }}</span>
+      <h1 class="display-5 mb-2">YOU vs {{ rival.public_name }}</h1>
+      <p class="lead text-secondary mb-0">
+        {% if game_mode == 'leg_claps' %}
+          {% blocktranslate with name=rival.public_name score=rival.score %}{{ name }} made {{ score }} Tung Tung Leg Claps in 20 seconds. Their video will play beside yours.{% endblocktranslate %}
+        {% else %}
+          {% blocktranslate with name=rival.public_name score=rival.score %}{{ name }} made {{ score }} 6️⃣7️⃣ moves in 20 seconds. Their video will play beside yours.{% endblocktranslate %}
+        {% endif %}
+      </p>
+    {% else %}
+      <span class="badge {% if game_mode == 'leg_claps' %}text-bg-success{% else %}text-bg-primary{% endif %} mode-badge mb-2">20 seconds · pose counter</span>
+      <h1 class="display-5 mb-2" id="counter-title">{% if game_mode == 'leg_claps' %}{% translate "Tung Tung Leg Claps" %}{% else %}67 Counter{% endif %}</h1>
+      {% if game_mode == 'leg_claps' %}<div class="text-secondary fw-semibold mb-2">酸黄瓜舞计数</div>{% endif %}
+      <p class="lead text-secondary mb-0" id="counter-description">{% if game_mode == 'leg_claps' %}{% translate "Count each time Tung Tung's knees swing inward from a clearly open position. The knees must open again before another clap." %}{% else %}{% translate "Move your arms up and down in the 6–7 pattern. Make as many counted moves as you can in 20 seconds." %}{% endif %}</p>
+    {% endif %}
+  </header>
+
+  <div class="alert alert-info py-2 px-3 small" role="note">
+    <strong>{% translate "Camera privacy:" %}</strong>
+    {% translate "Pose detection and recording run in this browser. Every run is recorded locally from the countdown, but nothing uploads unless you choose to submit it. Submitting publishes the video for everyone to watch; resetting or closing discards it." %}
+  </div>
+
+  <div class="row g-4 align-items-start">
+    <div class="{% if rival %}col-12 col-xl-9{% else %}col-12 col-lg-8{% endif %}">
+      <div class="row g-3">
+        {% if rival %}
+        <div class="col-12 col-md-6">
+          <section class="camera-card h-100">
+            <div class="camera-stage rival-stage">
+              <video id="rival-video" muted playsinline preload="auto" src="{% url 'brainrot:hall_of_fame_video' rival.id %}"></video>
+              <div class="rival-score-pill">
+                <span>{{ rival.public_name }}</span>
+                <strong id="rival-score">0</strong>
+              </div>
+            </div>
+            <div class="detector-status ready">
+              <span class="status-dot"></span>
+              <span>{% if rival_timeline_exact %}{% translate "Recorded event timeline ready" %}{% else %}{% translate "Legacy run · estimated count pace" %}{% endif %}</span>
+            </div>
+          </section>
+        </div>
+        {% endif %}
+
+        <div class="{% if rival %}col-12 col-md-6{% else %}col-12{% endif %}">
+          <section class="camera-card">
+            <div class="camera-stage" id="camera-stage">
+              <video id="camera" playsinline muted></video>
+              <canvas id="pose-overlay"></canvas>
+              <div class="camera-placeholder" id="camera-placeholder">
+                <span class="counter-placeholder-mark" id="counter-placeholder-mark">{% if game_mode == 'leg_claps' %}TT{% else %}67{% endif %}</span>
+                <span>{% translate "Camera is currently doing nothing." %}</span>
+              </div>
+              <div class="countdown" id="countdown" aria-live="assertive"></div>
+              <div class="live-pill" id="live-pill" hidden>● {% translate "RECORDING LOCALLY" %}</div>
+            </div>
+            <div class="detector-status" id="detector-status">
+              <span class="status-dot"></span>
+              <span>{% translate "Preloading pose model — camera remains off" %}</span>
+            </div>
+          </section>
+        </div>
+      </div>
     </div>
-    <div class="counter-hof-column">
-      <a class="counter-hof-portal" id="counter-hof-portal" href="{% url 'brainrot:hall_of_fame' %}?mode={{ game_mode }}">
-        <span class="counter-hof-eyebrow">{% translate "PUBLIC VIDEO LEADERBOARD" %}</span>
-        <span class="counter-hof-mark" id="counter-hof-mark">{% if game_mode == 'leg_claps' %}TT{% else %}67{% endif %}</span>
-        <strong>{% translate "HALL OF FAME" %}</strong>
-        <small>{% translate "Watch runs · preview videos · challenge scores" %} <b>→</b></small>
+
+    <aside class="{% if rival %}col-12 col-xl-3{% else %}col-12 col-lg-4{% endif %}">
+      <section class="score-card p-3 p-md-4 mb-3">
+        <div class="text-secondary small text-uppercase fw-semibold" id="score-label">{% if game_mode == 'leg_claps' %}{% translate "leg claps counted" %}{% else %}{% translate "6️⃣7️⃣ moves counted" %}{% endif %}</div>
+        <div class="score-value my-2" id="score">0</div>
+        <div class="d-flex justify-content-between align-items-end border-top pt-3 mb-3">
+          <span class="text-secondary small text-uppercase fw-semibold">{% translate "time remaining" %}</span>
+          <strong class="timer-value" id="counter-time">20.0</strong>
+        </div>
+
+        {% if rival %}
+        <div class="alert alert-light border py-2 px-3 small">
+          <span class="text-secondary">{% translate "score to beat" %}</span>
+          <strong class="float-end">{{ rival.score }}</strong><br>
+          <a href="{% url 'brainrot:hall_of_fame_detail' rival.id %}">{% translate "View HOF entry" %}</a>
+        </div>
+        {% endif %}
+
+        <div class="d-grid gap-2">
+          <button class="btn btn-primary" id="enable-camera">{% translate "Enable camera" %}</button>
+          <button class="btn btn-primary" id="start-run" disabled hidden>{% translate "Detector is still loading…" %}</button>
+          <button class="btn btn-outline-secondary" id="reset-run" hidden>{% translate "Run this foolish experiment again" %}</button>
+        </div>
+        <p class="small text-secondary mt-3 mb-0">{% translate "I'm ready starts a local recording with the live count burned into the video. Submitting remains your decision." %}</p>
+        <p class="counter-error text-danger small mt-2 mb-0" id="counter-error" role="alert"></p>
+      </section>
+
+      <a class="hof-card d-flex align-items-center gap-3 p-3 text-decoration-none text-body" id="counter-hof-portal" href="{% url 'brainrot:hall_of_fame' %}?mode={{ game_mode }}">
+        <span class="hof-mark" id="counter-hof-mark">{% if game_mode == 'leg_claps' %}TT{% else %}67{% endif %}</span>
+        <span>
+          <small class="text-secondary d-block">{% translate "PUBLIC VIDEO LEADERBOARD" %}</small>
+          <strong>{% translate "Hall of Fame" %} →</strong>
+        </span>
       </a>
       {% if request.user.is_authenticated %}
-      <a class="counter-my-hof" href="{% url 'brainrot:my_hall_of_fame' %}">{% if request.user.is_superuser %}{% translate "Manage all submitted runs" %}{% else %}{% translate "Manage my submitted runs" %}{% endif %} →</a>
+      <a class="d-block small mt-2" href="{% url 'brainrot:my_hall_of_fame' %}">{% if request.user.is_superuser %}{% translate "Manage all submitted runs" %}{% else %}{% translate "Manage my submitted runs" %}{% endif %}</a>
       {% endif %}
-    </div>
-  </section>
-
-  <section class="privacy-strip" aria-label="Camera privacy information">
-    <strong>{% translate "Camera privacy:" %}</strong> {% translate "Pose detection and recording run in this browser. Every run is recorded locally from the countdown, but nothing uploads unless you choose to submit it. Submitting publishes the video for everyone to watch; resetting or closing discards it." %}
-  </section>
-
-  <section class="counter-layout{% if rival %} challenge-layout{% endif %}">
-    {% if rival %}<div class="duel-grid">{% endif %}
-    {% if rival %}
-    <div class="camera-card rival-card">
-      <div class="camera-stage rival-stage">
-        <video id="rival-video" muted playsinline preload="auto"
-               src="{% url 'brainrot:hall_of_fame_video' rival.id %}"></video>
-        <div class="rival-score-pill">
-          <span>{{ rival.public_name }}</span>
-          <strong id="rival-score">0</strong>
-        </div>
-      </div>
-      <div class="detector-status ready">
-        <span class="status-dot"></span>
-        <span>{% if rival_timeline_exact %}{% translate "Recorded event timeline ready" %}{% else %}{% translate "Legacy run · estimated count pace" %}{% endif %}</span>
-      </div>
-    </div>
-    {% endif %}
-    <div class="camera-card">
-      <div class="camera-stage" id="camera-stage">
-        <video id="camera" playsinline muted></video>
-        <canvas id="pose-overlay"></canvas>
-        <div class="camera-placeholder" id="camera-placeholder">
-          <span class="placeholder-orbit" id="counter-placeholder-mark">{% if game_mode == 'leg_claps' %}TT{% else %}67{% endif %}</span>
-          <p>{% translate "Camera is currently doing nothing." %}</p>
-        </div>
-        <div class="countdown" id="countdown" aria-live="assertive"></div>
-        <div class="live-pill" id="live-pill" hidden>● {% translate "RECORDING LOCALLY" %}</div>
-      </div>
-      <div class="detector-status" id="detector-status">
-        <span class="status-dot"></span>
-        <span>{% translate "Preloading pose model — camera remains off" %}</span>
-      </div>
-    </div>
-    {% if rival %}</div>{% endif %}
-
-    <aside class="counter-panel">
-      <div class="score-block">
-        <span id="score-label">{% if game_mode == 'leg_claps' %}{% translate "leg claps counted" %}{% else %}{% translate "6️⃣7️⃣ moves counted" %}{% endif %}</span>
-        <strong id="score">0</strong>
-      </div>
-      <div class="timer-block"><span>{% translate "time remaining" %}</span><strong id="counter-time">20.0</strong></div>
-      {% if rival %}
-      <div class="challenge-target">
-        <span>{% translate "score to beat" %}</span>
-        <strong>{{ rival.score }}</strong>
-        <a href="{% url 'brainrot:hall_of_fame_detail' rival.id %}">{% translate "View HOF entry" %}</a>
-      </div>
-      {% endif %}
-
-      <button class="br-primary" id="enable-camera">{% translate "Enable camera" %}</button>
-      <button class="br-primary" id="start-run" disabled hidden>{% translate "Detector is still loading…" %}</button>
-      <p class="subtle run-consent">{% translate "I'm ready starts a local recording with the live count burned into the video. Submitting remains your decision." %}</p>
-      <button class="br-secondary" id="reset-run" hidden>{% translate "Run this foolish experiment again" %}</button>
-      <p class="counter-error" id="counter-error" role="alert"></p>
     </aside>
-  </section>
+  </div>
 
-  <section class="result-card" id="counter-result" hidden>
-    <div>
-      <span class="br-kicker">{% translate "PEER-REVIEWED BY YOURSELF" %}</span>
-      <h2><span id="result-score">0</span> <span id="result-unit">{% if game_mode == 'leg_claps' %}{% translate "leg claps in 20 seconds" %}{% else %}{% translate "6️⃣7️⃣ moves in 20 seconds" %}{% endif %}</span></h2>
-      <p id="result-copy">{% translate "A result has occurred." %}</p>
+  <section class="result-card p-3 p-md-4 mt-4" id="counter-result" hidden>
+    <div class="mb-4">
+      <div class="text-secondary small text-uppercase fw-semibold">RESULT</div>
+      <h2 class="h3 mt-1 mb-2"><span id="result-score">0</span> <span id="result-unit">{% if game_mode == 'leg_claps' %}{% translate "leg claps in 20 seconds" %}{% else %}{% translate "6️⃣7️⃣ moves in 20 seconds" %}{% endif %}</span></h2>
+      <p class="mb-0" id="result-copy">{% translate "A result has occurred." %}</p>
     </div>
-    <div class="recording-review" id="recording-review" hidden>
+
+    <div class="recording-review mb-4" id="recording-review" hidden>
       <video id="recording-preview" controls playsinline></video>
-      <p>{% translate "The recording remains local unless you submit it below. The downloaded and uploaded video includes the live count. Closing or resetting discards it." %}</p>
-      <a class="br-secondary br-button-link recording-download" id="download-recording" hidden>{% translate "Download counted video" %}</a>
+      <p class="small text-secondary mt-2">{% translate "The recording remains local unless you submit it below. The downloaded and uploaded video includes the live count. Closing or resetting discards it." %}</p>
+      <div class="d-flex flex-wrap gap-2 mb-3">
+        <a class="btn btn-outline-secondary" id="download-recording" hidden>{% translate "Download counted video" %}</a>
+      </div>
+
       {% if not request.user.is_authenticated and anonymous_submission_available %}
-        <label class="anonymous-name-field" for="hof-display-name">
+        <label class="anonymous-name-field form-label" for="hof-display-name">
           <span>{% translate "Anonymous display name" %}</span>
-          <input id="hof-display-name" maxlength="32" placeholder="Anonymous Swan">
+          <input class="form-control mt-1" id="hof-display-name" maxlength="32" placeholder="Anonymous Swan">
         </label>
-        <p class="subtle">{% translate "Guest runs are labelled “guest” and cannot impersonate registered usernames. Guest submissions have no self-service privacy or delete controls; contact me with the public HOF link for changes." %}
+        <p class="small text-secondary">{% translate "Guest runs are labelled “guest” and cannot impersonate registered usernames. Guest submissions have no self-service privacy or delete controls; contact me with the public HOF link for changes." %}
           <a href="{% url 'login' %}?next={{ request.path|urlencode }}">{% translate "Log in before another run" %}</a> {% translate "if you want ownership controls." %}</p>
       {% elif request.user.is_authenticated %}
-        <p class="subtle">{% blocktranslate with username=request.user.username %}Submitting as <strong>{{ username }}</strong>. New submissions are public, but you can later make the run private or delete it from My HOF.{% endblocktranslate %}</p>
+        <p class="small text-secondary">{% blocktranslate with username=request.user.username %}Submitting as <strong>{{ username }}</strong>. New submissions are public, but you can later make the run private or delete it from My HOF.{% endblocktranslate %}</p>
       {% else %}
-        <p class="subtle">{% translate "Anonymous submission is temporarily unavailable because the production human-verification gate is not configured." %}</p>
+        <p class="small text-secondary">{% translate "Anonymous submission is temporarily unavailable because the production human-verification gate is not configured." %}</p>
       {% endif %}
+
       {% if request.user.is_authenticated or anonymous_submission_available %}
-        {% if turnstile_enabled %}<div class="cf-turnstile" data-sitekey="{{ turnstile_site_key }}"></div>{% endif %}
-      <button class="br-primary" id="submit-hof" type="button">{% translate "Submit to Hall of Fame" %}</button>
-      <button class="br-text-button" id="discard-recording" type="button">{% translate "Discard recording" %}</button>
+        {% if turnstile_enabled %}<div class="cf-turnstile mb-3" data-sitekey="{{ turnstile_site_key }}"></div>{% endif %}
+        <div class="d-flex flex-wrap gap-2">
+          <button class="btn btn-primary" id="submit-hof" type="button">{% translate "Submit to Hall of Fame" %}</button>
+          <button class="btn btn-outline-danger" id="discard-recording" type="button">{% translate "Discard recording" %}</button>
+        </div>
       {% else %}
-        <a class="br-primary br-button-link" href="{% url 'login' %}?next={{ request.path|urlencode }}">{% translate "Log in to submit this run" %}</a>
-        <button class="br-text-button" id="discard-recording" type="button">{% translate "Discard recording" %}</button>
+        <div class="d-flex flex-wrap gap-2">
+          <a class="btn btn-primary" href="{% url 'login' %}?next={{ request.path|urlencode }}">{% translate "Log in to submit this run" %}</a>
+          <button class="btn btn-outline-danger" id="discard-recording" type="button">{% translate "Discard recording" %}</button>
+        </div>
       {% endif %}
-      <p id="upload-status" role="status"></p>
+      <p class="small mt-2 mb-0" id="upload-status" role="status"></p>
     </div>
-    <div class="counter-share" id="counter-share">
-      <h3>🎉 {% translate "Share your result!" %}</h3>
-      <textarea id="counter-share-text" rows="6" readonly aria-label="Shareable counter result"></textarea>
-      <button class="br-secondary" id="copy-counter-share" type="button">{% translate "Copy to clipboard" %}</button>
-      <p class="subtle" id="copy-counter-status" role="status" aria-live="polite"></p>
+
+    <div class="counter-share border-top pt-4" id="counter-share">
+      <h3 class="h5">🎉 {% translate "Share your result!" %}</h3>
+      <textarea class="form-control mb-2" id="counter-share-text" rows="5" readonly aria-label="Shareable counter result"></textarea>
+      <button class="btn btn-outline-primary" id="copy-counter-share" type="button">{% translate "Copy to clipboard" %}</button>
+      <p class="small text-secondary mt-2 mb-0" id="copy-counter-status" role="status" aria-live="polite"></p>
     </div>
   </section>
 </main>
@@ -182,21 +199,21 @@
   <div class="publication-modal-backdrop" data-close-publication-modal></div>
   <section class="publication-modal-card">
     <button class="publication-modal-close" type="button" data-close-publication-modal aria-label="{% translate 'Close' %}">×</button>
-    <span class="br-kicker">{% translate "PUBLICATION CONSENT" %}</span>
-    <h2 id="publication-modal-title">{% translate "Your video will be public" %}</h2>
+    <div class="text-secondary small text-uppercase fw-semibold mb-2">{% translate "PUBLICATION CONSENT" %}</div>
+    <h2 class="h4" id="publication-modal-title">{% translate "Your video will be public" %}</h2>
     <p>{% translate "Submitting publishes this recording to the 67 Hall of Fame. Anyone can watch, download and share it." %}</p>
     {% if request.user.is_authenticated %}
-    <p class="publication-modal-note">{% translate "Because you are logged in, you can make it private or delete it later from My HOF." %}</p>
+      <p class="small text-secondary">{% translate "Because you are logged in, you can make it private or delete it later from My HOF." %}</p>
     {% else %}
-    <p class="publication-modal-note">{% translate "Guest submissions cannot be privately managed or deleted by you later. Contact the site owner with the HOF link if you need it removed." %}</p>
+      <p class="small text-secondary">{% translate "Guest submissions cannot be privately managed or deleted by you later. Contact the site owner with the HOF link if you need it removed." %}</p>
     {% endif %}
     <label class="publication-consent-check">
-      <input type="checkbox" id="publication-consent">
+      <input class="form-check-input" type="checkbox" id="publication-consent">
       <span>{% translate "I understand that my video will be published for anyone to watch." %}</span>
     </label>
     <div class="publication-modal-actions">
-      <button class="br-secondary" id="cancel-publication" type="button">{% translate "Not now" %}</button>
-      <button class="br-primary" id="confirm-publication" type="button" disabled>{% translate "Publish this video" %}</button>
+      <button class="btn btn-outline-secondary" id="cancel-publication" type="button">{% translate "Not now" %}</button>
+      <button class="btn btn-primary" id="confirm-publication" type="button" disabled>{% translate "Publish this video" %}</button>
     </div>
   </section>
 </div>
@@ -205,7 +222,6 @@
 {{ rival_timeline|json_script:'rival-event-timeline' }}
 {% endif %}
 
-{# Keep this version in step with counter.js so browsers cannot retain a broken runtime URL. #}
 <script src="{% url 'brainrot:javascript_catalog' %}"></script>
-<script type="module" src="{% static 'brainrot/counter.js' %}?v=20260817.2"></script>
+<script type="module" src="{% static 'brainrot/counter.js' %}"></script>
 {% endblock %}

--- a/brainrot/templates/brainrot/hall_of_fame.html
+++ b/brainrot/templates/brainrot/hall_of_fame.html
@@ -4,63 +4,82 @@
 {% block title %}{% if game_mode == 'leg_claps' %}{% translate "Tung Tung Leg Claps Hall of Fame" %}{% else %}{% translate "67 Hall of Fame" %}{% endif %}{% endblock %}
 
 {% block content %}
-<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260817.2">
-<main class="br-page hall-page">
-  <header class="br-toolbar">
-    <a href="{% url 'brainrot:counter' %}?mode={{ game_mode }}">← {% if game_mode == 'leg_claps' %}{% translate "Tung Tung Leg Claps" %}{% else %}{% translate "67 Counter" %}{% endif %}</a>
+<main class="container py-4 py-md-5">
+  <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-4">
+    <a class="btn btn-sm btn-outline-secondary" href="{% url 'brainrot:index' %}">← {% translate "All experiments" %}</a>
     {% if request.user.is_authenticated %}
-    <a href="{% url 'brainrot:my_hall_of_fame' %}">{% if request.user.is_superuser %}{% translate "Manage HOF" %}{% else %}{% translate "My HOF" %}{% endif %}</a>
-    {% else %}
-    <a href="{% url 'brainrot:index' %}">{% translate "All experiments" %}</a>
+      <a class="btn btn-sm btn-outline-dark" href="{% url 'brainrot:my_hall_of_fame' %}">{% if request.user.is_superuser %}{% translate "Manage HOF" %}{% else %}{% translate "My HOF" %}{% endif %}</a>
     {% endif %}
-  </header>
-  <nav class="hall-mode-switcher" aria-label="{% translate 'Leaderboard mode' %}">
-    <a href="{% url 'brainrot:hall_of_fame' %}?mode=six_seven" class="{% if game_mode == 'six_seven' %}active{% endif %}">67 Counter</a>
-    <a href="{% url 'brainrot:hall_of_fame' %}?mode=leg_claps" class="{% if game_mode == 'leg_claps' %}active{% endif %}">{% translate "Tung Tung Leg Claps" %}</a>
-  </nav>
-  <section class="hall-heading">
-    <span class="br-kicker">{% translate "PUBLIC 20-SECOND VIDEO LEADERBOARD" %}</span>
-    <h1>{% if game_mode == 'leg_claps' %}{% translate "Leg Claps Hall of Fame" %}{% else %}{% translate "67 Hall of Fame" %}{% endif %}</h1>
-    <p>{% if game_mode == 'leg_claps' %}{% translate "See who made the most inward knee claps in 20 seconds, watch each run, then challenge it yourself. Each clap requires the knees to open again before the next count." %}{% else %}{% translate "See who made the most 6️⃣7️⃣ moves in 20 seconds, watch each run, then challenge it yourself. Guest names are visibly labelled and cannot copy registered usernames." %}{% endif %}</p>
-  </section>
+  </div>
 
-  <section class="hall-list">
+  <div class="row g-4 align-items-end mb-4">
+    <div class="col-12 col-lg-8">
+      <div class="text-secondary small text-uppercase fw-semibold mb-2">{% translate "PUBLIC 20-SECOND VIDEO LEADERBOARD" %}</div>
+      <h1 class="display-5 fw-bold mb-2">{% if game_mode == 'leg_claps' %}{% translate "Leg Claps Hall of Fame" %}{% else %}{% translate "67 Hall of Fame" %}{% endif %}</h1>
+      <p class="lead text-secondary mb-0">{% if game_mode == 'leg_claps' %}{% translate "See who made the most inward knee claps in 20 seconds, watch each run, then challenge it yourself. Each clap requires the knees to open again before the next count." %}{% else %}{% translate "See who made the most 6️⃣7️⃣ moves in 20 seconds, watch each run, then challenge it yourself. Guest names are visibly labelled and cannot copy registered usernames." %}{% endif %}</p>
+    </div>
+    <div class="col-12 col-lg-4 text-lg-end">
+      <div class="btn-group" role="group" aria-label="{% translate 'Leaderboard mode' %}">
+        <a class="btn {% if game_mode == 'six_seven' %}btn-primary{% else %}btn-outline-primary{% endif %}" href="{% url 'brainrot:hall_of_fame' %}?mode=six_seven">67 Counter</a>
+        <a class="btn {% if game_mode == 'leg_claps' %}btn-success{% else %}btn-outline-success{% endif %}" href="{% url 'brainrot:hall_of_fame' %}?mode=leg_claps">{% translate "Tung Tung Leg Claps" %}</a>
+      </div>
+    </div>
+  </div>
+
+  <div class="d-grid gap-3">
     {% for entry in entries %}
-    <article class="hall-entry">
-      <span class="hall-rank">#{{ forloop.counter }}</span>
-      <div class="hall-person">
-        <strong>{{ entry.public_name }}</strong>
-        <span>{% if entry.game_mode == 'leg_claps' %}{% blocktranslate with score=entry.score date=entry.created_at|date:'j M Y' %}made {{ score }} leg claps in 20 seconds · {{ date }}{% endblocktranslate %}{% else %}{% blocktranslate with score=entry.score date=entry.created_at|date:'j M Y' %}made {{ score }} 6️⃣7️⃣ moves in 20 seconds · {{ date }}{% endblocktranslate %}{% endif %}</span>
-      </div>
-      <strong class="hall-score">{{ entry.score }}<small>{% if entry.game_mode == 'leg_claps' %}{% translate "claps" %}{% else %}{% translate "moves" %}{% endif %}</small></strong>
-      <div class="hall-actions">
-        <a href="{% url 'brainrot:hall_of_fame_detail' entry.id %}">{% translate "Full details" %}</a>
-        <a href="{% url 'brainrot:challenge' entry.id %}">{% translate "Challenge this run" %}</a>
-      </div>
-      {% url 'brainrot:hall_of_fame_video' entry.id as preview_url %}
-      <details class="hall-preview">
-        <summary>{% translate "Watch video preview" %}</summary>
-        <div class="hall-preview-body">
-          <video controls preload="none" playsinline src="{{ preview_url }}"></video>
-          <div>
-            <strong>{% if entry.game_mode == 'leg_claps' %}{% blocktranslate with name=entry.public_name score=entry.score %}{{ name }} made {{ score }} Tung Tung Leg Claps in 20 seconds.{% endblocktranslate %}{% else %}{% blocktranslate with name=entry.public_name score=entry.score %}{{ name }} made {{ score }} 6️⃣7️⃣ moves in 20 seconds.{% endblocktranslate %}{% endif %}</strong>
-            <span>{% translate "Open the detail page to share this run, download it, or start a synchronized challenge." %}</span>
-            <div class="hall-preview-links">
-              <a href="{% url 'brainrot:hall_of_fame_detail' entry.id %}">{% translate "Open full run" %} →</a>
-              <a href="{{ preview_url }}?download=1">{% translate "Download video" %}</a>
+    <article class="card shadow-sm">
+      <div class="card-body p-3 p-md-4">
+        <div class="row g-3 align-items-center">
+          <div class="col-auto">
+            <span class="badge text-bg-light border text-dark fs-6">#{{ forloop.counter }}</span>
+          </div>
+          <div class="col">
+            <h2 class="h5 border-0 ps-0 ms-0 mb-1">{{ entry.public_name }}</h2>
+            <div class="text-secondary small">
+              {% if entry.game_mode == 'leg_claps' %}{% blocktranslate with score=entry.score date=entry.created_at|date:'j M Y' %}made {{ score }} leg claps in 20 seconds · {{ date }}{% endblocktranslate %}{% else %}{% blocktranslate with score=entry.score date=entry.created_at|date:'j M Y' %}made {{ score }} 6️⃣7️⃣ moves in 20 seconds · {{ date }}{% endblocktranslate %}{% endif %}
             </div>
           </div>
+          <div class="col-auto text-end">
+            <div class="display-6 fw-bold">{{ entry.score }}</div>
+            <small class="text-secondary">{% if entry.game_mode == 'leg_claps' %}{% translate "claps" %}{% else %}{% translate "moves" %}{% endif %}</small>
+          </div>
         </div>
-      </details>
-      {% if request.user.is_superuser %}{% include 'brainrot/_entry_controls.html' %}{% endif %}
+
+        <div class="d-flex flex-wrap gap-2 mt-3">
+          <a class="btn btn-sm btn-outline-dark" href="{% url 'brainrot:hall_of_fame_detail' entry.id %}">{% translate "Full details" %}</a>
+          <a class="btn btn-sm btn-primary" href="{% url 'brainrot:challenge' entry.id %}">{% translate "Challenge this run" %}</a>
+        </div>
+
+        {% url 'brainrot:hall_of_fame_video' entry.id as preview_url %}
+        <details class="mt-3">
+          <summary class="text-primary fw-semibold" style="cursor:pointer">{% translate "Watch video preview" %}</summary>
+          <div class="row g-3 mt-1 align-items-start">
+            <div class="col-12 col-lg-6">
+              <video class="w-100 rounded bg-dark" controls preload="none" playsinline src="{{ preview_url }}"></video>
+            </div>
+            <div class="col-12 col-lg-6">
+              <strong>{% if entry.game_mode == 'leg_claps' %}{% blocktranslate with name=entry.public_name score=entry.score %}{{ name }} made {{ score }} Tung Tung Leg Claps in 20 seconds.{% endblocktranslate %}{% else %}{% blocktranslate with name=entry.public_name score=entry.score %}{{ name }} made {{ score }} 6️⃣7️⃣ moves in 20 seconds.{% endblocktranslate %}{% endif %}</strong>
+              <p class="text-secondary small mt-2">{% translate "Open the detail page to share this run, download it, or start a synchronized challenge." %}</p>
+              <div class="d-flex flex-wrap gap-2">
+                <a href="{% url 'brainrot:hall_of_fame_detail' entry.id %}">{% translate "Open full run" %} →</a>
+                <a href="{{ preview_url }}?download=1">{% translate "Download video" %}</a>
+              </div>
+            </div>
+          </div>
+        </details>
+        {% if request.user.is_superuser %}{% include 'brainrot/_entry_controls.html' %}{% endif %}
+      </div>
     </article>
     {% empty %}
-    <div class="empty-hall">
-      <strong>{% translate "No legends yet." %}</strong>
-      <p>{% translate "The scientific community has uploaded absolutely nothing." %}</p>
-      <a href="{% url 'brainrot:counter' %}?mode={{ game_mode }}" class="br-primary br-button-link">{% translate "Submit the first specimen" %}</a>
+    <div class="card border-dashed">
+      <div class="card-body p-4 text-center">
+        <h2 class="h4 border-0 ps-0 ms-0">{% translate "No legends yet." %}</h2>
+        <p class="text-secondary">{% translate "The scientific community has uploaded absolutely nothing." %}</p>
+        <a href="{% url 'brainrot:counter' %}?mode={{ game_mode }}" class="btn btn-primary">{% translate "Submit the first specimen" %}</a>
+      </div>
     </div>
     {% endfor %}
-  </section>
+  </div>
 </main>
 {% endblock %}

--- a/brainrot/templates/brainrot/hall_of_fame_detail.html
+++ b/brainrot/templates/brainrot/hall_of_fame_detail.html
@@ -4,61 +4,77 @@
 {% block title %}{{ entry.public_name }} — {% if entry.game_mode == 'leg_claps' %}{% translate "Tung Tung Leg Claps Hall of Fame" %}{% else %}{% translate "67 Hall of Fame" %}{% endif %}{% endblock %}
 
 {% block content %}
-<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260817.2">
-<main class="br-page hall-detail-page" id="hof-detail"
+<main class="container py-4 py-md-5" id="hof-detail"
       data-entry-url="{{ request.build_absolute_uri }}"
       data-username="{{ entry.public_name }}"
       data-score="{{ entry.score }}"
       data-game-mode="{{ entry.game_mode }}">
-  <header class="br-toolbar">
-    <a href="{% url 'brainrot:hall_of_fame' %}?mode={{ entry.game_mode }}">← {% translate "Hall of Fame" %}</a>
-    <a href="{% url 'brainrot:index' %}">{% translate "All experiments" %}</a>
-  </header>
+  <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-4">
+    <a class="btn btn-sm btn-outline-secondary" href="{% url 'brainrot:hall_of_fame' %}?mode={{ entry.game_mode }}">← {% translate "Hall of Fame" %}</a>
+    <a class="btn btn-sm btn-outline-dark" href="{% url 'brainrot:index' %}">{% translate "All experiments" %}</a>
+  </div>
 
-  <section class="hall-detail-heading">
-    <span class="br-kicker">{% blocktranslate with id=entry.id %}ARCHIVED HUMAN PERFORMANCE SPECIMEN #{{ id }}{% endblocktranslate %}</span>
-    <h1>{{ entry.score }}</h1>
-    <div>
-      <strong>{% if entry.game_mode == 'leg_claps' %}{% blocktranslate with name=entry.public_name score=entry.score %}{{ name }} made {{ score }} Tung Tung Leg Claps in 20 seconds.{% endblocktranslate %}{% else %}{% blocktranslate with name=entry.public_name score=entry.score %}{{ name }} made {{ score }} 6️⃣7️⃣ moves in 20 seconds.{% endblocktranslate %}{% endif %}</strong>
-      <span>{{ entry.created_at|date:'j M Y · H:i' }} · {% blocktranslate with duration=entry.duration_seconds|floatformat:2 %}{{ duration }} seconds{% endblocktranslate %}</span>
-      <span class="game-mode-badge game-mode-{{ entry.game_mode }}">{{ entry.get_game_mode_display }}</span>
-      <span class="visibility-badge visibility-{{ entry.visibility }}">{{ entry.get_visibility_display }}</span>
+  <div class="row g-4 align-items-start mb-4">
+    <div class="col-12 col-lg-8">
+      <div class="text-secondary small text-uppercase fw-semibold mb-2">{% blocktranslate with id=entry.id %}ARCHIVED HUMAN PERFORMANCE SPECIMEN #{{ id }}{% endblocktranslate %}</div>
+      <div class="d-flex flex-wrap align-items-end gap-3">
+        <h1 class="display-2 fw-bold mb-0">{{ entry.score }}</h1>
+        <div class="pb-2">
+          <div class="fw-bold">{% if entry.game_mode == 'leg_claps' %}{% blocktranslate with name=entry.public_name score=entry.score %}{{ name }} made {{ score }} Tung Tung Leg Claps in 20 seconds.{% endblocktranslate %}{% else %}{% blocktranslate with name=entry.public_name score=entry.score %}{{ name }} made {{ score }} 6️⃣7️⃣ moves in 20 seconds.{% endblocktranslate %}{% endif %}</div>
+          <div class="text-secondary small">{{ entry.created_at|date:'j M Y · H:i' }} · {% blocktranslate with duration=entry.duration_seconds|floatformat:2 %}{{ duration }} seconds{% endblocktranslate %}</div>
+        </div>
+      </div>
+      <div class="d-flex flex-wrap gap-2 mt-2">
+        <span class="badge {% if entry.game_mode == 'leg_claps' %}text-bg-success{% else %}text-bg-primary{% endif %}">{{ entry.get_game_mode_display }}</span>
+        <span class="badge {% if entry.visibility == 'public' %}text-bg-success{% else %}text-bg-secondary{% endif %}">{{ entry.get_visibility_display }}</span>
+      </div>
     </div>
-  </section>
+  </div>
 
   {% url 'brainrot:hall_of_fame_video' entry.id as evidence_url %}
-  <section class="hall-detail-grid">
-    <div class="hall-evidence-card">
-      <video controls preload="metadata" playsinline src="{{ evidence_url }}"></video>
-      <div class="hall-evidence-actions">
-        <a class="br-secondary br-button-link" href="{{ evidence_url }}?download=1">{% translate "Download counted video" %}</a>
-        {% if entry.visibility == 'public' %}
-        <a class="br-primary br-button-link" href="{% url 'brainrot:challenge' entry.id %}">{% translate "Challenge this specimen" %}</a>
-        {% endif %}
+  <div class="row g-4">
+    <div class="col-12 col-lg-8">
+      <div class="card shadow-sm">
+        <div class="card-body p-3">
+          <video class="w-100 rounded bg-dark" controls preload="metadata" playsinline src="{{ evidence_url }}"></video>
+          <div class="d-flex flex-wrap gap-2 mt-3">
+            <a class="btn btn-outline-secondary" href="{{ evidence_url }}?download=1">{% translate "Download counted video" %}</a>
+            {% if entry.visibility == 'public' %}
+            <a class="btn btn-primary" href="{% url 'brainrot:challenge' entry.id %}">{% translate "Challenge this specimen" %}</a>
+            {% endif %}
+          </div>
+        </div>
       </div>
     </div>
 
-    <aside class="hall-share-card">
-      <span class="br-kicker">{% if entry.visibility == 'public' %}{% translate "PUBLIC REPLICATION MATERIAL" %}{% else %}{% translate "PRIVATE OWNER VIEW" %}{% endif %}</span>
-      <h2>{% if entry.visibility == 'public' %}{% translate "Share this run" %}{% else %}{% translate "Private run" %}{% endif %}</h2>
-      {% if entry.visibility == 'private' %}
-      <p>{% translate "Only you and site superusers can open this page or video. Publish it to restore its Hall of Fame listing and share link." %}</p>
-      {% elif entry.user_id and request.user == entry.user %}
-      <p>{% translate "This is your permanent Hall of Fame link. Deploy it responsibly." %}</p>
-      {% elif not entry.user_id %}
-      <p>{% translate "This is a guest submission and has no self-service access. To request privacy changes or removal, contact the site owner and include this page's URL." %}</p>
-      {% else %}
-      <p>{% translate "Distribute this evidence to researchers, rivals and confused relatives." %}</p>
-      {% endif %}
-      {% if entry.visibility == 'public' %}
-      <textarea id="hof-share-text" rows="6" readonly aria-label="Shareable Hall of Fame result"></textarea>
-      <button class="br-primary" id="share-hof" type="button">{% translate "Share result!" %}</button>
-      <button class="br-secondary" id="copy-hof-link" type="button">{% translate "Copy share message" %}</button>
-      {% endif %}
-      {% include 'brainrot/_entry_controls.html' %}
-      <p class="subtle" id="hof-share-status" role="status" aria-live="polite"></p>
-    </aside>
-  </section>
+    <div class="col-12 col-lg-4">
+      <aside class="card shadow-sm">
+        <div class="card-body p-3 p-md-4">
+          <div class="text-secondary small text-uppercase fw-semibold mb-2">{% if entry.visibility == 'public' %}{% translate "PUBLIC REPLICATION MATERIAL" %}{% else %}{% translate "PRIVATE OWNER VIEW" %}{% endif %}</div>
+          <h2 class="h4 border-0 ps-0 ms-0">{% if entry.visibility == 'public' %}{% translate "Share this run" %}{% else %}{% translate "Private run" %}{% endif %}</h2>
+          {% if entry.visibility == 'private' %}
+            <p class="text-secondary small">{% translate "Only you and site superusers can open this page or video. Publish it to restore its Hall of Fame listing and share link." %}</p>
+          {% elif entry.user_id and request.user == entry.user %}
+            <p class="text-secondary small">{% translate "This is your permanent Hall of Fame link. Deploy it responsibly." %}</p>
+          {% elif not entry.user_id %}
+            <p class="text-secondary small">{% translate "This is a guest submission and has no self-service access. To request privacy changes or removal, contact the site owner and include this page's URL." %}</p>
+          {% else %}
+            <p class="text-secondary small">{% translate "Distribute this evidence to researchers, rivals and confused relatives." %}</p>
+          {% endif %}
+
+          {% if entry.visibility == 'public' %}
+            <textarea class="form-control mb-2" id="hof-share-text" rows="6" readonly aria-label="Shareable Hall of Fame result"></textarea>
+            <div class="d-grid gap-2">
+              <button class="btn btn-primary" id="share-hof" type="button">{% translate "Share result!" %}</button>
+              <button class="btn btn-outline-secondary" id="copy-hof-link" type="button">{% translate "Copy share message" %}</button>
+            </div>
+          {% endif %}
+          {% include 'brainrot/_entry_controls.html' %}
+          <p class="small text-secondary mt-2 mb-0" id="hof-share-status" role="status" aria-live="polite"></p>
+        </div>
+      </aside>
+    </div>
+  </div>
 </main>
 {% if entry.visibility == 'public' %}
 <script src="{% url 'brainrot:javascript_catalog' %}"></script>

--- a/brainrot/templates/brainrot/index.html
+++ b/brainrot/templates/brainrot/index.html
@@ -4,40 +4,61 @@
 {% block title %}{% translate "Institute of 61/67 Studies" %}{% endblock %}
 
 {% block content %}
-<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260817.2">
-<main class="br-page">
-  <section class="br-hero">
-    <span class="br-kicker">{% translate "ICAiJY INSTITUTE OF NUMERICAL CULTURE" %}</span>
-    <h1>{% translate "61 / 67 Research Division" %}</h1>
-    <p>{% translate "Two controlled experiments. No useful findings are expected." %}</p>
-  </section>
-  <a class="br-hof-banner" href="{% url 'brainrot:hall_of_fame' %}">
+<main class="container py-4 py-md-5">
+  <div class="d-flex flex-column flex-lg-row align-items-lg-end justify-content-between gap-3 mb-4 mb-md-5">
     <div>
-      <span class="br-kicker">{% translate "PUBLIC 20-SECOND VIDEO LEADERBOARD" %}</span>
-      <h2>{% translate "Pose Hall of Fame" %}</h2>
-      <p>{% translate "Watch 67 arm runs or Tung Tung knee runs, share the evidence, or challenge a score." %}</p>
+      <div class="text-secondary small text-uppercase fw-semibold mb-2">{% translate "ICAiJY INSTITUTE OF NUMERICAL CULTURE" %}</div>
+      <h1 class="display-5 fw-bold mb-2">{% translate "61 / 67 Research Division" %}</h1>
+      <p class="lead text-secondary mb-0">Choose a scientifically unnecessary experiment.</p>
     </div>
-    <strong>{% translate "Enter the archive" %} →</strong>
-  </a>
-  <section class="br-game-grid" aria-label="Experiments">
-    <a class="br-game-card br-counter-card" href="{% url 'brainrot:counter' %}">
-      <span class="br-card-number">67</span>
-      <div>
-        <span class="br-kicker">{% translate "EXPERIMENT 01" %}</span>
-        <h2>{% translate "67 Counter" %}</h2>
-        <p>{% translate "Local pose tracking for 67 arms and Tung Tung knees, with one camera and approximately zero dignity." %}</p>
-      </div>
-      <span class="br-card-arrow">{% translate "Begin" %} →</span>
+    <a class="btn btn-outline-dark" href="{% url 'brainrot:hall_of_fame' %}">
+      <i class="fa-solid fa-ranking-star me-1"></i> {% translate "Pose Hall of Fame" %}
     </a>
-    <a class="br-game-card br-typing-card" href="{% url 'brainrot:typing_test' %}">
-      <span class="br-card-number">61</span>
-      <div>
-        <span class="br-kicker">{% translate "EXPERIMENT 02" %}</span>
-        <h2>{% translate "61 / 67 Typing Test" %}</h2>
-        <p>{% translate "Modern typing science, stripped of every unnecessary character." %}</p>
-      </div>
-      <span class="br-card-arrow">{% translate "Type" %} →</span>
-    </a>
-  </section>
+  </div>
+
+  <div class="row g-3 g-lg-4">
+    <div class="col-12 col-md-6 col-xl-4">
+      <a class="card h-100 text-decoration-none text-body shadow-sm border-primary" href="{% url 'brainrot:counter' %}?mode=six_seven">
+        <div class="card-body p-4 d-flex flex-column">
+          <div class="d-flex align-items-start justify-content-between gap-3 mb-4">
+            <span class="badge text-bg-primary">20 s · camera</span>
+            <span class="display-6 fw-bold text-primary">67</span>
+          </div>
+          <h2 class="h3 fw-bold">{% translate "67 Counter" %}</h2>
+          <p class="text-secondary flex-grow-1 mb-4">{% translate "Move your arms up and down in the 6–7 pattern. Make as many counted moves as you can in 20 seconds." %}</p>
+          <span class="fw-semibold text-primary">{% translate "Begin" %} →</span>
+        </div>
+      </a>
+    </div>
+
+    <div class="col-12 col-md-6 col-xl-4">
+      <a class="card h-100 text-decoration-none text-body shadow-sm border-success" href="{% url 'brainrot:counter' %}?mode=leg_claps">
+        <div class="card-body p-4 d-flex flex-column">
+          <div class="d-flex align-items-start justify-content-between gap-3 mb-4">
+            <span class="badge text-bg-success">20 s · camera</span>
+            <span class="display-6 fw-bold text-success">TT</span>
+          </div>
+          <h2 class="h3 fw-bold mb-1">{% translate "Tung Tung Leg Claps" %}</h2>
+          <div class="small text-secondary mb-3">酸黄瓜舞计数</div>
+          <p class="text-secondary flex-grow-1 mb-4">{% translate "Count each time Tung Tung's knees swing inward from a clearly open position. The knees must open again before another clap." %}</p>
+          <span class="fw-semibold text-success">{% translate "Begin" %} →</span>
+        </div>
+      </a>
+    </div>
+
+    <div class="col-12 col-md-6 col-xl-4">
+      <a class="card h-100 text-decoration-none text-body shadow-sm border-secondary" href="{% url 'brainrot:typing_test' %}">
+        <div class="card-body p-4 d-flex flex-column">
+          <div class="d-flex align-items-start justify-content-between gap-3 mb-4">
+            <span class="badge text-bg-secondary">keyboard</span>
+            <span class="display-6 fw-bold text-secondary">61</span>
+          </div>
+          <h2 class="h3 fw-bold">{% translate "61 / 67 Typing Test" %}</h2>
+          <p class="text-secondary flex-grow-1 mb-4">{% translate "Modern typing science, stripped of every unnecessary character." %}</p>
+          <span class="fw-semibold text-secondary">{% translate "Type" %} →</span>
+        </div>
+      </a>
+    </div>
+  </div>
 </main>
 {% endblock %}

--- a/brainrot/templates/brainrot/my_hall_of_fame.html
+++ b/brainrot/templates/brainrot/my_hall_of_fame.html
@@ -4,47 +4,52 @@
 {% block title %}My 67 Hall of Fame{% endblock %}
 
 {% block content %}
-<link rel="stylesheet" href="{% static 'brainrot/brainrot.css' %}?v=20260817.2">
-<main class="br-page hall-page">
-  <header class="br-toolbar">
-    <a href="{% url 'brainrot:hall_of_fame' %}">← {% translate "Public Hall of Fame" %}</a>
-    <a href="{% url 'brainrot:counter' %}">{% translate "New run" %}</a>
-  </header>
+<main class="container py-4 py-md-5">
+  <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-4">
+    <a class="btn btn-sm btn-outline-secondary" href="{% url 'brainrot:hall_of_fame' %}">← {% translate "Public Hall of Fame" %}</a>
+    <a class="btn btn-sm btn-primary" href="{% url 'brainrot:counter' %}">{% translate "New run" %}</a>
+  </div>
 
-  <section class="hall-heading">
-    <span class="br-kicker">{% if superuser_mode %}{% translate "SUPERUSER HALL OF FAME CONTROL" %}{% else %}{% translate "PERSONAL ARM-ACTIVITY RECORDS" %}{% endif %}</span>
-    <h1>{% if superuser_mode %}{% translate "Manage HOF" %}{% else %}{% translate "My HOF" %}{% endif %}</h1>
-    <p>{% if superuser_mode %}{% translate "You can change visibility or delete any registered or guest run." %}{% else %}{% translate "Your runs can be public or private. Deleting one removes both its listing and video file." %}{% endif %}</p>
-  </section>
+  <div class="mb-4">
+    <div class="text-secondary small text-uppercase fw-semibold mb-2">{% if superuser_mode %}{% translate "SUPERUSER HALL OF FAME CONTROL" %}{% else %}{% translate "PERSONAL ARM-ACTIVITY RECORDS" %}{% endif %}</div>
+    <h1 class="display-5 fw-bold mb-2">{% if superuser_mode %}{% translate "Manage HOF" %}{% else %}{% translate "My HOF" %}{% endif %}</h1>
+    <p class="lead text-secondary mb-0">{% if superuser_mode %}{% translate "You can change visibility or delete any registered or guest run." %}{% else %}{% translate "Your runs can be public or private. Deleting one removes both its listing and video file." %}{% endif %}</p>
+  </div>
 
   {% if request.GET.deleted %}
-  <p class="hof-delete-notice" role="status">{% translate "Entry and recording deleted. The evidence has left the building." %}</p>
+    <div class="alert alert-success" role="status">{% translate "Entry and recording deleted. The evidence has left the building." %}</div>
   {% elif request.GET.updated %}
-  <p class="hof-delete-notice" role="status">{% translate "Visibility updated." %}</p>
+    <div class="alert alert-success" role="status">{% translate "Visibility updated." %}</div>
   {% endif %}
 
-  <section class="hall-list">
+  <div class="d-grid gap-3">
     {% for entry in entries %}
-    <article class="hall-entry my-hall-entry">
-      <span class="hall-rank">#{{ entry.id }}</span>
-      <div class="hall-person">
-        <strong>{% if superuser_mode %}{{ entry.public_name }} · {% endif %}{{ entry.created_at|date:'j M Y · H:i' }}</strong>
-        <span>{{ entry.get_game_mode_display }} · {{ entry.get_visibility_display }} · {% blocktranslate with duration=entry.duration_seconds|floatformat:2 %}{{ duration }} seconds{% endblocktranslate %}</span>
+    <article class="card shadow-sm">
+      <div class="card-body p-3 p-md-4">
+        <div class="row g-3 align-items-center">
+          <div class="col-auto"><span class="badge text-bg-light border text-dark">#{{ entry.id }}</span></div>
+          <div class="col">
+            <h2 class="h5 border-0 ps-0 ms-0 mb-1">{% if superuser_mode %}{{ entry.public_name }} · {% endif %}{{ entry.created_at|date:'j M Y · H:i' }}</h2>
+            <div class="text-secondary small">{{ entry.get_game_mode_display }} · {{ entry.get_visibility_display }} · {% blocktranslate with duration=entry.duration_seconds|floatformat:2 %}{{ duration }} seconds{% endblocktranslate %}</div>
+          </div>
+          <div class="col-auto"><span class="display-6 fw-bold">{{ entry.score }}</span></div>
+        </div>
+        <div class="d-flex flex-wrap gap-2 mt-3">
+          <a class="btn btn-sm btn-outline-dark" href="{% url 'brainrot:hall_of_fame_detail' entry.id %}">{% translate "View" %}</a>
+          <a class="btn btn-sm btn-outline-secondary" href="{% url 'brainrot:hall_of_fame_video' entry.id %}?download=1">{% translate "Download" %}</a>
+        </div>
+        {% include 'brainrot/_entry_controls.html' %}
       </div>
-      <strong class="hall-score">{{ entry.score }}</strong>
-      <div class="hall-actions">
-        <a href="{% url 'brainrot:hall_of_fame_detail' entry.id %}">{% translate "View" %}</a>
-        <a href="{% url 'brainrot:hall_of_fame_video' entry.id %}?download=1">{% translate "Download" %}</a>
-      </div>
-      {% include 'brainrot/_entry_controls.html' %}
     </article>
     {% empty %}
-    <div class="empty-hall">
-      <strong>{% translate "No owned specimens yet." %}</strong>
-      <p>{% translate "Anonymous submissions cannot be retroactively attached to this account." %}</p>
-      <a href="{% url 'brainrot:counter' %}" class="br-primary br-button-link">{% translate "Create an unnecessarily documented run" %}</a>
+    <div class="card">
+      <div class="card-body p-4 text-center">
+        <h2 class="h4 border-0 ps-0 ms-0">{% translate "No owned specimens yet." %}</h2>
+        <p class="text-secondary">{% translate "Anonymous submissions cannot be retroactively attached to this account." %}</p>
+        <a href="{% url 'brainrot:counter' %}" class="btn btn-primary">{% translate "Create an unnecessarily documented run" %}</a>
+      </div>
     </div>
     {% endfor %}
-  </section>
+  </div>
 </main>
 {% endblock %}

--- a/brainrot/tests.py
+++ b/brainrot/tests.py
@@ -25,11 +25,17 @@ class BrainrotPageTests(TestCase):
         self.assertEqual(legacy.status_code, 301)
         self.assertEqual(legacy['Location'], '/67/')
 
+        index = self.client.get('/67/')
+        self.assertContains(index, '/67/counter/?mode=six_seven')
+        self.assertContains(index, '/67/counter/?mode=leg_claps')
+        self.assertContains(index, 'Tung Tung Leg Claps')
+
     @override_settings(DEBUG=True)
-    def test_counter_uses_cache_busted_runtime_and_has_share_box(self):
+    def test_counter_uses_shared_runtime_and_has_share_box(self):
         response = self.client.get('/67/counter/')
-        self.assertContains(response, 'brainrot.css?v=20260817.2')
-        self.assertContains(response, 'counter.js?v=20260817.2')
+        self.assertContains(response, 'brainrot/counter_bootstrap.css')
+        self.assertContains(response, 'brainrot/counter.js')
+        self.assertNotContains(response, '?v=20260817.2')
         self.assertContains(response, 'id="counter-share-text"')
         self.assertContains(response, 'id="copy-counter-share"')
         self.assertContains(response, 'id="download-recording"')
@@ -44,9 +50,7 @@ class BrainrotPageTests(TestCase):
         self.assertContains(response, 'id="start-run" disabled hidden')
         self.assertContains(response, 'id="counter-hof-portal"')
         self.assertContains(response, 'PUBLIC VIDEO LEADERBOARD')
-        self.assertContains(response, 'type="button" data-counter-mode="six_seven"')
-        self.assertContains(response, 'type="button" data-counter-mode="leg_claps"')
-        self.assertNotContains(response, 'hof-nav-link')
+        self.assertNotContains(response, 'data-counter-mode=')
         self.assertNotContains(response, 'Log in to submit this run')
 
         script_path = finders.find('brainrot/counter.js')
@@ -59,7 +63,7 @@ class BrainrotPageTests(TestCase):
         self.assertIn("new URL('/67/counter/', window.location.origin)", script)
         self.assertIn('preloadPoseRuntime();', script)
         self.assertLess(script.index('preloadPoseRuntime();'), script.index("enableButton.addEventListener('click'"))
-        self.assertIn("from './gesture_engine.js?v=20260817.2'", script)
+        self.assertIn("from './gesture_engine.js'", script)
         self.assertIn('let currentMode =', script)
         self.assertIn('createGestureTracker(currentMode)', script)
         self.assertIn('const GAME_SECONDS = 20;', script)
@@ -76,6 +80,8 @@ class BrainrotPageTests(TestCase):
         self.assertIn("form.append('game_mode', currentMode);", script)
         self.assertIn('drawRecordingHud();', script)
         self.assertIn("'67 COUNT'", script)
+        self.assertIn("hudBrand: 'icaijy.com'", script)
+        self.assertNotIn('ICAiJY', script)
         self.assertIn("const rawResponse = await response.text();", script)
         self.assertIn('payload = JSON.parse(rawResponse);', script)
         self.assertNotIn('await response.json()', script)
@@ -88,15 +94,22 @@ class BrainrotPageTests(TestCase):
         self.assertIsNotNone(engine_path)
         engine = Path(engine_path).read_text(encoding='utf-8')
         self.assertIn("LEG_CLAPS: 'leg_claps'", engine)
-        self.assertIn('[23, 24, 25, 26, 27, 28]', engine)
-        self.assertIn('this.readyForClose = false;', engine)
+        self.assertIn('[23, 24, 25, 26]', engine)
+        self.assertIn('LEG_CLAP_CLOSE_RATIO = 0.42', engine)
+        self.assertIn('LEG_CLAP_REOPEN_RATIO = 0.62', engine)
+        self.assertNotIn('stableSinceOpen', engine)
 
-    def test_counter_mode_switch_is_server_rendered_and_invalid_mode_falls_back(self):
+    def test_counter_modes_are_separate_entries_and_invalid_mode_falls_back(self):
         leg_claps = self.client.get('/67/counter/?mode=leg_claps')
         self.assertContains(leg_claps, 'data-game-mode="leg_claps"')
-        self.assertContains(leg_claps, 'TUNG TUNG LEG CLAPS')
-        self.assertContains(leg_claps, 'data-counter-mode="leg_claps" class="active"')
+        self.assertContains(leg_claps, 'Tung Tung Leg Claps')
+        self.assertContains(leg_claps, '酸黄瓜舞计数')
         self.assertContains(leg_claps, 'leg claps counted')
+        self.assertNotContains(leg_claps, 'data-counter-mode=')
+
+        six_seven = self.client.get('/67/counter/?mode=six_seven')
+        self.assertContains(six_seven, 'data-game-mode="six_seven"')
+        self.assertContains(six_seven, '67 Counter')
 
         fallback = self.client.get('/67/counter/?mode=not-a-real-experiment')
         self.assertContains(fallback, 'data-game-mode="six_seven"')


### PR DESCRIPTION
## What changed
- make `/67/` present 67 Counter, Tung Tung Leg Claps, and Typing as separate Bootstrap-style game cards
- rebuild the shared camera counter page around the site's existing Bootstrap shell instead of the oversized custom lab UI
- rebuild the Hall of Fame list, detail, ownership/management UI, and public/private controls with Bootstrap so the pose-game flow has one visual language
- keep the same 20-second timer, camera, local recording, Hall of Fame submission, challenge, and `game_mode` backend infrastructure
- remove the visible in-page 67/Tung Tung mode switcher; the two pose games now enter through explicit URLs while still sharing the same implementation
- replace the recorded-video `ICAiJY` label with the consistent `icaijy.com` brand
- simplify leg-clap recognition to a knee-distance hysteresis state machine using only hips + knees

## Leg-clap rule
The tracker normalises horizontal knee gap by horizontal hip width:
- **re-arm/open:** ratio >= 0.62 for 2 frames
- **count/closed:** ratio <= 0.42 for 2 frames
- after a count it must reopen before another count
- ankles are not required and no ankle/hip baseline stability test is used
- losing required knee/hip tracking disarms the cycle to avoid a ghost count on re-entry

The state-machine shape is intentional and robust; the exact 0.42/0.62 values are initial camera-calibration values because there is no authoritative Tung Tung reference implementation or labelled dataset. They are isolated constants so a real-camera pass can tune them without touching the rest of the detector.

## Validation
- local Node gesture tests: **5/5 passed**
  - existing 67 direction-change rule preserved
  - close only counts once
  - reopen required for another count
  - starting closed does not count
  - ankles can be invisible
  - tracking loss disarms the cycle
- updated Django page/source assertions for the new Bootstrap UI and detector implementation
- reviewed the final diff to ensure the 20-second deadline guard, MediaPipe runtime, canvas recording, event timeline, HOF upload, and challenge flow remain shared and intact
- this repository currently has no GitHub Actions workflow, so the full Django suite was not executable through CI from this environment

Real camera movement still needs a human calibration pass for the two leg-clap thresholds.