### PR TITLE
Fix Tung Tung leg clap detection and counter UI

### DIFF
--- a/brainrot/js_tests/gesture_engine.test.mjs
+++ b/brainrot/js_tests/gesture_engine.test.mjs
@@ -74,7 +74,7 @@ test('starting inward never counts until a clearly open pose has armed the track
 test('a slightly wider-than-hip knee gap still counts as inward', () => {
   const tracker = createGestureTracker(GAME_MODES.LEG_CLAPS);
   assert.equal(tracker.observe(legPose(0.30), 100), false);
-  assert.equal(tracker.observe(legPose(0.24), 133), true);
+  assert.equal(tracker.observe(legPose(0.23), 133), true);
 });
 
 test('leg-clap readiness only requires hips and knees, not feet', () => {

--- a/brainrot/js_tests/gesture_engine.test.mjs
+++ b/brainrot/js_tests/gesture_engine.test.mjs
@@ -43,42 +43,42 @@ test('the existing 67 direction-change rule is preserved', () => {
   assert.equal(tracker.observe(sixSevenPose(0.70, 0.30), 400), true);
 });
 
-test('a leg clap counts close once and requires a clear reopen before re-arming', () => {
+test('a leg clap counts when knee gap returns to about hip width', () => {
   const tracker = createGestureTracker(GAME_MODES.LEG_CLAPS);
 
-  // hip width is .20, so .14 knee gap = .70 (open) and .07 = .35 (closed).
-  assert.equal(tracker.observe(legPose(0.14), 100), false);
-  assert.equal(tracker.observe(legPose(0.14), 133), false);
-  assert.equal(tracker.observe(legPose(0.07), 200), false);
-  assert.equal(tracker.observe(legPose(0.07), 233), true);
+  // Hip width is .20. An open .30 gap is 1.50x hip width; a .22 inward gap is 1.10x.
+  assert.equal(tracker.observe(legPose(0.30), 100), false);
+  assert.equal(tracker.observe(legPose(0.22), 133), true);
 
-  // Staying closed cannot farm counts.
-  assert.equal(tracker.observe(legPose(0.06), 266), false);
-  assert.equal(tracker.observe(legPose(0.07), 299), false);
+  // Staying inward cannot farm counts.
+  assert.equal(tracker.observe(legPose(0.20), 166), false);
+  assert.equal(tracker.observe(legPose(0.23), 199), false);
 
-  // A partial opening inside the hysteresis band is not enough.
-  assert.equal(tracker.observe(legPose(0.11), 332), false);
-  assert.equal(tracker.observe(legPose(0.07), 365), false);
+  // A partial opening inside the hysteresis band is not enough to re-arm.
+  assert.equal(tracker.observe(legPose(0.25), 232), false);
+  assert.equal(tracker.observe(legPose(0.21), 265), false);
 
-  // Reopen for two frames, then another close can count.
-  assert.equal(tracker.observe(legPose(0.14), 400), false);
-  assert.equal(tracker.observe(legPose(0.14), 433), false);
-  assert.equal(tracker.observe(legPose(0.07), 466), false);
-  assert.equal(tracker.observe(legPose(0.07), 499), true);
+  // A clearly wider knee gap re-arms immediately for the next inward swing.
+  assert.equal(tracker.observe(legPose(0.29), 298), false);
+  assert.equal(tracker.observe(legPose(0.21), 331), true);
 });
 
-test('starting closed never counts until an open pose has armed the tracker', () => {
+test('starting inward never counts until a clearly open pose has armed the tracker', () => {
   const tracker = createGestureTracker(GAME_MODES.LEG_CLAPS);
-  assert.equal(tracker.observe(legPose(0.06), 100), false);
-  assert.equal(tracker.observe(legPose(0.06), 133), false);
-  assert.equal(tracker.observe(legPose(0.14), 166), false);
-  assert.equal(tracker.observe(legPose(0.14), 199), false);
-  assert.equal(tracker.observe(legPose(0.07), 232), false);
-  assert.equal(tracker.observe(legPose(0.07), 265), true);
+  assert.equal(tracker.observe(legPose(0.20), 100), false);
+  assert.equal(tracker.observe(legPose(0.22), 133), false);
+  assert.equal(tracker.observe(legPose(0.30), 166), false);
+  assert.equal(tracker.observe(legPose(0.23), 199), true);
+});
+
+test('a slightly wider-than-hip knee gap still counts as inward', () => {
+  const tracker = createGestureTracker(GAME_MODES.LEG_CLAPS);
+  assert.equal(tracker.observe(legPose(0.30), 100), false);
+  assert.equal(tracker.observe(legPose(0.24), 133), true);
 });
 
 test('leg-clap readiness only requires hips and knees, not feet', () => {
-  const pose = legPose(0.14, { ankleVisible: false });
+  const pose = legPose(0.30, { ankleVisible: false });
   assert.equal(landmarksAreVisible(GAME_MODES.LEG_CLAPS, pose), true);
   pose[25].visibility = 0.1;
   assert.equal(landmarksAreVisible(GAME_MODES.LEG_CLAPS, pose), false);
@@ -86,11 +86,14 @@ test('leg-clap readiness only requires hips and knees, not feet', () => {
 
 test('losing knee tracking disarms the current leg-clap cycle', () => {
   const tracker = createGestureTracker(GAME_MODES.LEG_CLAPS);
-  assert.equal(tracker.observe(legPose(0.14), 100), false);
-  assert.equal(tracker.observe(legPose(0.14), 133), false);
-  const lost = legPose(0.07);
+  assert.equal(tracker.observe(legPose(0.30), 100), false);
+
+  const lost = legPose(0.22);
   lost[25].visibility = 0.1;
-  assert.equal(tracker.observe(lost, 166), false);
-  assert.equal(tracker.observe(legPose(0.07), 199), false);
-  assert.equal(tracker.observe(legPose(0.07), 232), false);
+  assert.equal(tracker.observe(lost, 133), false);
+
+  // Reappearing inward is not enough; a new open pose is required.
+  assert.equal(tracker.observe(legPose(0.22), 166), false);
+  assert.equal(tracker.observe(legPose(0.30), 199), false);
+  assert.equal(tracker.observe(legPose(0.22), 232), true);
 });

--- a/brainrot/static/brainrot/counter.js
+++ b/brainrot/static/brainrot/counter.js
@@ -250,17 +250,15 @@ if (app) {
         ? `I made ${score} Tung Tung Leg Claps in 20 seconds against ${rivalName}'s ${rivalFinalScore}.`
         : `I made ${score} 6️⃣7️⃣ moves in 20 seconds against ${rivalName}'s ${rivalFinalScore}.`
       : isLegClaps
-        ? `I made ${score} Tung Tung Leg Claps in 20 seconds. The knees have submitted their findings. 🥒`
-        : score === 67
-          ? 'I made exactly 67 6️⃣7️⃣ moves in 20 seconds. Peer review is complete. 🧪'
-          : `I made ${score} 6️⃣7️⃣ moves in 20 seconds.`;
+        ? `I made ${score} Tung Tung Leg Claps in 20 seconds.`
+        : `I made ${score} 6️⃣7️⃣ moves in 20 seconds.`;
     const blocks = score > 0
       ? `${'🟩'.repeat(Math.min(score, 67))}${score > 67 ? ` +${score - 67}` : ''}`
       : '⬜';
     const pageUrl = rivalName ? new URL(window.location.href) : new URL('/67/counter/', window.location.origin);
     pageUrl.searchParams.set('mode', currentMode);
-    const experiment = isLegClaps ? 'TUNG TUNG LEG CLAPS · 酸黄瓜舞计数' : 'SIX SEVEN';
-    return `${headline}\n${blocks}\n${experiment}\nWatch the run or try to beat it.\n${pageUrl.href}`;
+    const gameName = isLegClaps ? 'TUNG TUNG LEG CLAPS' : '67 COUNTER';
+    return `${headline}\n${blocks}\n${gameName}\n${pageUrl.href}`;
   }
 
   async function copyShareResult() {
@@ -274,7 +272,7 @@ if (app) {
         if (!document.execCommand('copy')) throw new Error('Copy command was rejected.');
       }
       copyShareButton.textContent = tr('Copied! 🎉');
-      copyShareStatus.textContent = tr('Result copied. Scientific distribution may begin.');
+      copyShareStatus.textContent = tr('Result copied.');
     } catch (error) {
       copyShareStatus.textContent = tr('Automatic copy failed. Select the text and copy it manually.');
     }
@@ -330,7 +328,7 @@ if (app) {
   }
 
   function observeGesture(landmarks, now) {
-    if (!running || now >= endTime || !sufficientlyVisible(landmarks)) return;
+    if (!running || now >= endTime) return;
     if (gestureTracker.observe(landmarks, now)) {
       score += 1;
       scoreEl.textContent = score;
@@ -620,7 +618,7 @@ if (app) {
     if (rivalVideo && Math.abs(rivalVideo.currentTime - RECORDING_LEAD_SECONDS) > 0.35) {
       rivalVideo.currentTime = RECORDING_LEAD_SECONDS;
     }
-    setStatus(tr('Experiment in progress'), 'ready');
+    setStatus(tr('Run in progress'), 'ready');
     gameLoop = requestAnimationFrame(updateGameClock);
   }
 
@@ -638,19 +636,19 @@ if (app) {
     resultScore.textContent = score;
     resultCopy.textContent = rivalName
       ? score > rivalFinalScore
-        ? `You defeated ${rivalName} by ${score - rivalFinalScore}. The archive has been destabilised.`
+        ? `You beat ${rivalName} by ${score - rivalFinalScore}.`
         : score === rivalFinalScore
-          ? `A draw with ${rivalName}. Statistically annoying.`
-          : `${rivalName} remains ahead by ${rivalFinalScore - score}. Replication is encouraged.`
+          ? `You tied ${rivalName}.`
+          : `${rivalName} is ahead by ${rivalFinalScore - score}.`
       : currentMode === GAME_MODES.LEG_CLAPS
         ? score > 0
-          ? tr('The knees opened, closed and produced a statistically usable result.')
-          : tr('No inward knee events were observed. The pickle remains motionless.')
+          ? `Counted ${score} leg claps.`
+          : tr('No leg claps were counted.')
         : score === 67
-          ? tr('Exactly 67. There will be no further questions.')
+          ? tr('Exactly 67.')
           : score > 67
-            ? tr('The 67 barrier has been disturbed.')
-            : tr('The Institute recommends more arm-based research.');
+            ? `You passed 67 with ${score} moves.`
+            : `Counted ${score} moves.`;
     shareText.value = shareableResult();
     copyShareStatus.textContent = '';
     resultCard.hidden = false;
@@ -732,7 +730,7 @@ if (app) {
     if (turnstileResponse) form.append('cf-turnstile-response', turnstileResponse);
 
     submitButton.disabled = true;
-    uploadStatus.textContent = tr('Uploading public evidence after the timer has safely stopped…');
+    uploadStatus.textContent = tr('Uploading video…');
     try {
       const response = await fetch(app.dataset.submitUrl, {
         method: 'POST',

--- a/brainrot/static/brainrot/gesture_engine.js
+++ b/brainrot/static/brainrot/gesture_engine.js
@@ -70,12 +70,12 @@ class SixSevenTracker {
   }
 }
 
-// These are intentionally boring, easy-to-tune thresholds rather than an
-// attempt to infer whether feet/hips stayed perfectly fixed. kneeRatio is the
-// horizontal knee gap divided by horizontal hip width.
-const LEG_CLAP_CLOSE_RATIO = 0.42;
-const LEG_CLAP_REOPEN_RATIO = 0.62;
-const LEG_CLAP_STABLE_FRAMES = 2;
+// For this dance, the knees are roughly one hip-width apart at the inward
+// point. Opening the knees makes that horizontal gap clearly wider than the
+// hips. The gap between these thresholds is deliberate hysteresis so one pose
+// cannot repeatedly count from small landmark jitter.
+const LEG_CLAP_CLOSE_RATIO = 1.20;
+const LEG_CLAP_REOPEN_RATIO = 1.35;
 
 class LegClapTracker {
   constructor() {
@@ -84,8 +84,6 @@ class LegClapTracker {
 
   reset() {
     this.armed = false;
-    this.openFrames = 0;
-    this.closedFrames = 0;
   }
 
   kneeRatio(landmarks) {
@@ -99,10 +97,8 @@ class LegClapTracker {
 
   observe(landmarks) {
     if (!landmarksAreVisible(GAME_MODES.LEG_CLAPS, landmarks)) {
-      this.openFrames = 0;
-      this.closedFrames = 0;
       // Require a fresh visible open pose after tracking is lost. This avoids
-      // counting a person merely re-entering the frame with their knees closed.
+      // counting a person merely re-entering the frame at the inward point.
       this.armed = false;
       return false;
     }
@@ -110,28 +106,13 @@ class LegClapTracker {
     const ratio = this.kneeRatio(landmarks);
 
     if (ratio >= LEG_CLAP_REOPEN_RATIO) {
-      this.closedFrames = 0;
-      this.openFrames += 1;
-      if (this.openFrames >= LEG_CLAP_STABLE_FRAMES) this.armed = true;
+      this.armed = true;
       return false;
     }
 
-    this.openFrames = 0;
-    if (ratio > LEG_CLAP_CLOSE_RATIO) {
-      this.closedFrames = 0;
-      return false;
-    }
-
-    if (!this.armed) {
-      this.closedFrames = 0;
-      return false;
-    }
-
-    this.closedFrames += 1;
-    if (this.closedFrames < LEG_CLAP_STABLE_FRAMES) return false;
+    if (ratio > LEG_CLAP_CLOSE_RATIO || !this.armed) return false;
 
     this.armed = false;
-    this.closedFrames = 0;
     return true;
   }
 }

--- a/brainrot/templates/brainrot/counter.html
+++ b/brainrot/templates/brainrot/counter.html
@@ -33,7 +33,7 @@
   </div>
 
   <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-4">
-    <a class="btn btn-sm btn-outline-secondary" href="{% url 'brainrot:index' %}">← {% translate "Research division" %}</a>
+    <a class="btn btn-sm btn-outline-secondary" href="{% url 'brainrot:index' %}">← 67 Games</a>
     <a class="btn btn-sm btn-outline-dark" href="{% url 'brainrot:hall_of_fame' %}?mode={{ game_mode }}">
       <i class="fa-solid fa-ranking-star me-1"></i> {% translate "Hall of Fame" %}
     </a>
@@ -51,9 +51,8 @@
         {% endif %}
       </p>
     {% else %}
-      <span class="badge {% if game_mode == 'leg_claps' %}text-bg-success{% else %}text-bg-primary{% endif %} mode-badge mb-2">20 seconds · pose counter</span>
+      <span class="badge {% if game_mode == 'leg_claps' %}text-bg-success{% else %}text-bg-primary{% endif %} mode-badge mb-2">20 seconds · camera</span>
       <h1 class="display-5 mb-2" id="counter-title">{% if game_mode == 'leg_claps' %}{% translate "Tung Tung Leg Claps" %}{% else %}67 Counter{% endif %}</h1>
-      {% if game_mode == 'leg_claps' %}<div class="text-secondary fw-semibold mb-2">酸黄瓜舞计数</div>{% endif %}
       <p class="lead text-secondary mb-0" id="counter-description">{% if game_mode == 'leg_claps' %}{% translate "Count each time Tung Tung's knees swing inward from a clearly open position. The knees must open again before another clap." %}{% else %}{% translate "Move your arms up and down in the 6–7 pattern. Make as many counted moves as you can in 20 seconds." %}{% endif %}</p>
     {% endif %}
   </header>
@@ -91,7 +90,7 @@
               <canvas id="pose-overlay"></canvas>
               <div class="camera-placeholder" id="camera-placeholder">
                 <span class="counter-placeholder-mark" id="counter-placeholder-mark">{% if game_mode == 'leg_claps' %}TT{% else %}67{% endif %}</span>
-                <span>{% translate "Camera is currently doing nothing." %}</span>
+                <span>Camera off</span>
               </div>
               <div class="countdown" id="countdown" aria-live="assertive"></div>
               <div class="live-pill" id="live-pill" hidden>● {% translate "RECORDING LOCALLY" %}</div>
@@ -125,16 +124,16 @@
         <div class="d-grid gap-2">
           <button class="btn btn-primary" id="enable-camera">{% translate "Enable camera" %}</button>
           <button class="btn btn-primary" id="start-run" disabled hidden>{% translate "Detector is still loading…" %}</button>
-          <button class="btn btn-outline-secondary" id="reset-run" hidden>{% translate "Run this foolish experiment again" %}</button>
+          <button class="btn btn-outline-secondary" id="reset-run" hidden>Try again</button>
         </div>
-        <p class="small text-secondary mt-3 mb-0">{% translate "I'm ready starts a local recording with the live count burned into the video. Submitting remains your decision." %}</p>
+        <p class="small text-secondary mt-3 mb-0">The run is recorded locally with the live count on the video. Nothing uploads unless you submit it.</p>
         <p class="counter-error text-danger small mt-2 mb-0" id="counter-error" role="alert"></p>
       </section>
 
       <a class="hof-card d-flex align-items-center gap-3 p-3 text-decoration-none text-body" id="counter-hof-portal" href="{% url 'brainrot:hall_of_fame' %}?mode={{ game_mode }}">
         <span class="hof-mark" id="counter-hof-mark">{% if game_mode == 'leg_claps' %}TT{% else %}67{% endif %}</span>
         <span>
-          <small class="text-secondary d-block">{% translate "PUBLIC VIDEO LEADERBOARD" %}</small>
+          <small class="text-secondary d-block">VIDEO LEADERBOARD</small>
           <strong>{% translate "Hall of Fame" %} →</strong>
         </span>
       </a>
@@ -148,7 +147,7 @@
     <div class="mb-4">
       <div class="text-secondary small text-uppercase fw-semibold">RESULT</div>
       <h2 class="h3 mt-1 mb-2"><span id="result-score">0</span> <span id="result-unit">{% if game_mode == 'leg_claps' %}{% translate "leg claps in 20 seconds" %}{% else %}{% translate "6️⃣7️⃣ moves in 20 seconds" %}{% endif %}</span></h2>
-      <p class="mb-0" id="result-copy">{% translate "A result has occurred." %}</p>
+      <p class="mb-0" id="result-copy">Run complete.</p>
     </div>
 
     <div class="recording-review mb-4" id="recording-review" hidden>
@@ -201,7 +200,7 @@
     <button class="publication-modal-close" type="button" data-close-publication-modal aria-label="{% translate 'Close' %}">×</button>
     <div class="text-secondary small text-uppercase fw-semibold mb-2">{% translate "PUBLICATION CONSENT" %}</div>
     <h2 class="h4" id="publication-modal-title">{% translate "Your video will be public" %}</h2>
-    <p>{% translate "Submitting publishes this recording to the 67 Hall of Fame. Anyone can watch, download and share it." %}</p>
+    <p>Submitting publishes this recording to the Hall of Fame. Anyone can watch, download and share it.</p>
     {% if request.user.is_authenticated %}
       <p class="small text-secondary">{% translate "Because you are logged in, you can make it private or delete it later from My HOF." %}</p>
     {% else %}

--- a/brainrot/templates/brainrot/index.html
+++ b/brainrot/templates/brainrot/index.html
@@ -1,18 +1,18 @@
 {% extends 'base.html' %}
 {% load static i18n %}
 
-{% block title %}{% translate "Institute of 61/67 Studies" %}{% endblock %}
+{% block title %}67 Games{% endblock %}
 
 {% block content %}
 <main class="container py-4 py-md-5">
   <div class="d-flex flex-column flex-lg-row align-items-lg-end justify-content-between gap-3 mb-4 mb-md-5">
     <div>
-      <div class="text-secondary small text-uppercase fw-semibold mb-2">{% translate "ICAiJY INSTITUTE OF NUMERICAL CULTURE" %}</div>
-      <h1 class="display-5 fw-bold mb-2">{% translate "61 / 67 Research Division" %}</h1>
-      <p class="lead text-secondary mb-0">Choose a scientifically unnecessary experiment.</p>
+      <div class="text-secondary small text-uppercase fw-semibold mb-2">icaijy.com</div>
+      <h1 class="display-5 fw-bold mb-2">67 Games</h1>
+      <p class="lead text-secondary mb-0">Pick a game and start a 20-second run.</p>
     </div>
     <a class="btn btn-outline-dark" href="{% url 'brainrot:hall_of_fame' %}">
-      <i class="fa-solid fa-ranking-star me-1"></i> {% translate "Pose Hall of Fame" %}
+      <i class="fa-solid fa-ranking-star me-1"></i> {% translate "Hall of Fame" %}
     </a>
   </div>
 
@@ -38,8 +38,7 @@
             <span class="badge text-bg-success">20 s · camera</span>
             <span class="display-6 fw-bold text-success">TT</span>
           </div>
-          <h2 class="h3 fw-bold mb-1">{% translate "Tung Tung Leg Claps" %}</h2>
-          <div class="small text-secondary mb-3">酸黄瓜舞计数</div>
+          <h2 class="h3 fw-bold mb-3">{% translate "Tung Tung Leg Claps" %}</h2>
           <p class="text-secondary flex-grow-1 mb-4">{% translate "Count each time Tung Tung's knees swing inward from a clearly open position. The knees must open again before another clap." %}</p>
           <span class="fw-semibold text-success">{% translate "Begin" %} →</span>
         </div>
@@ -54,7 +53,7 @@
             <span class="display-6 fw-bold text-secondary">61</span>
           </div>
           <h2 class="h3 fw-bold">{% translate "61 / 67 Typing Test" %}</h2>
-          <p class="text-secondary flex-grow-1 mb-4">{% translate "Modern typing science, stripped of every unnecessary character." %}</p>
+          <p class="text-secondary flex-grow-1 mb-4">Type 61 and 67 as quickly and accurately as you can.</p>
           <span class="fw-semibold text-secondary">{% translate "Type" %} →</span>
         </div>
       </a>

--- a/brainrot/tests.py
+++ b/brainrot/tests.py
@@ -29,6 +29,8 @@ class BrainrotPageTests(TestCase):
         self.assertContains(index, '/67/counter/?mode=six_seven')
         self.assertContains(index, '/67/counter/?mode=leg_claps')
         self.assertContains(index, 'Tung Tung Leg Claps')
+        self.assertNotContains(index, '酸黄瓜舞计数')
+        self.assertNotContains(index, 'INSTITUTE OF NUMERICAL CULTURE')
 
     @override_settings(DEBUG=True)
     def test_counter_uses_shared_runtime_and_has_share_box(self):
@@ -49,7 +51,9 @@ class BrainrotPageTests(TestCase):
         self.assertContains(response, 'id="hof-display-name"')
         self.assertContains(response, 'id="start-run" disabled hidden')
         self.assertContains(response, 'id="counter-hof-portal"')
-        self.assertContains(response, 'PUBLIC VIDEO LEADERBOARD')
+        self.assertContains(response, 'VIDEO LEADERBOARD')
+        self.assertNotContains(response, 'PUBLIC VIDEO LEADERBOARD')
+        self.assertNotContains(response, 'Run this foolish experiment again')
         self.assertNotContains(response, 'data-counter-mode=')
         self.assertNotContains(response, 'Log in to submit this run')
 
@@ -67,7 +71,8 @@ class BrainrotPageTests(TestCase):
         self.assertIn('let currentMode =', script)
         self.assertIn('createGestureTracker(currentMode)', script)
         self.assertIn('const GAME_SECONDS = 20;', script)
-        self.assertIn('if (!running || now >= endTime || !sufficientlyVisible(landmarks)) return;', script)
+        self.assertIn('if (!running || now >= endTime) return;', script)
+        self.assertNotIn('if (!running || now >= endTime || !sufficientlyVisible(landmarks)) return;', script)
         self.assertIn('gestureTracker.reset();', script)
         self.assertIn('setModeControlsDisabled(true);', script)
         self.assertIn('const blob = await stopRecording();', script)
@@ -82,6 +87,9 @@ class BrainrotPageTests(TestCase):
         self.assertIn("'67 COUNT'", script)
         self.assertIn("hudBrand: 'icaijy.com'", script)
         self.assertNotIn('ICAiJY', script)
+        self.assertNotIn('酸黄瓜舞计数', script)
+        self.assertNotIn('pickle remains motionless', script)
+        self.assertNotIn('Institute recommends', script)
         self.assertIn("const rawResponse = await response.text();", script)
         self.assertIn('payload = JSON.parse(rawResponse);', script)
         self.assertNotIn('await response.json()', script)
@@ -95,15 +103,16 @@ class BrainrotPageTests(TestCase):
         engine = Path(engine_path).read_text(encoding='utf-8')
         self.assertIn("LEG_CLAPS: 'leg_claps'", engine)
         self.assertIn('[23, 24, 25, 26]', engine)
-        self.assertIn('LEG_CLAP_CLOSE_RATIO = 0.42', engine)
-        self.assertIn('LEG_CLAP_REOPEN_RATIO = 0.62', engine)
+        self.assertIn('LEG_CLAP_CLOSE_RATIO = 1.20', engine)
+        self.assertIn('LEG_CLAP_REOPEN_RATIO = 1.35', engine)
+        self.assertNotIn('LEG_CLAP_STABLE_FRAMES', engine)
         self.assertNotIn('stableSinceOpen', engine)
 
     def test_counter_modes_are_separate_entries_and_invalid_mode_falls_back(self):
         leg_claps = self.client.get('/67/counter/?mode=leg_claps')
         self.assertContains(leg_claps, 'data-game-mode="leg_claps"')
         self.assertContains(leg_claps, 'Tung Tung Leg Claps')
-        self.assertContains(leg_claps, '酸黄瓜舞计数')
+        self.assertNotContains(leg_claps, '酸黄瓜舞计数')
         self.assertContains(leg_claps, 'leg claps counted')
         self.assertNotContains(leg_claps, 'data-counter-mode=')
 
@@ -116,7 +125,7 @@ class BrainrotPageTests(TestCase):
 
     def test_brainrot_pages_have_chinese_translation(self):
         response = self.client.get('/67/', HTTP_ACCEPT_LANGUAGE='zh-hans')
-        self.assertContains(response, '61 / 67 研究部')
+        self.assertContains(response, '酸黄瓜舞计数')
         counter = self.client.get('/67/counter/', HTTP_ACCEPT_LANGUAGE='zh-hans')
         self.assertContains(counter, '启用摄像头')
         self.assertContains(counter, '你的视频将会公开')


### PR DESCRIPTION
## What changed

- Reworked Tung Tung Leg Claps around the actual geometry of the move: at the inward point, horizontal knee gap is roughly one hip width; opening the knees makes that gap clearly wider.
- Count when `kneeGap / hipWidth <= 1.20`, then require `>= 1.35` before another clap can count.
- Removed the old two-consecutive-frame requirement so fast inward peaks are not missed.
- Let the gesture tracker receive lost-landmark frames so it can actually disarm after tracking loss.
- Preserved the existing 67 direction-change detector and the shared 20-second timer/recording/Hall of Fame pipeline.
- Removed hard-coded Chinese from English pages and share text. Chinese still comes from the existing gettext translation for `Tung Tung Leg Claps`.
- Simplified Work-era UI copy (`Institute`, `research division`, `foolish experiment`, pickle/scientific-result jokes) while keeping the existing Bootstrap presentation.
- Updated JS and Django regression assertions to match the corrected geometry and English/Chinese separation.

## Validation

- Local Node gesture tests: **6/6 passed**
  - existing 67 detector preserved
  - open → inward counts once
  - staying inward cannot farm counts
  - hysteresis requires a clear reopen
  - starting inward does not count
  - feet are not required
  - lost knee tracking disarms the cycle
- Final diff touches only 6 frontend/test files; no backend model, API, migration, timer, upload or HOF storage changes.

The `1.20 / 1.35` thresholds are intentionally easy to tune after a real camera test.