### PR TITLE
Localize 67 share messages

### DIFF
--- a/brainrot/static/brainrot/counter_share_locale.js
+++ b/brainrot/static/brainrot/counter_share_locale.js
@@ -1,0 +1,42 @@
+(() => {
+  const app = document.getElementById('counter-app');
+  const resultCard = document.getElementById('counter-result');
+  const shareText = document.getElementById('counter-share-text');
+  const scoreEl = document.getElementById('score');
+  if (!app || !resultCard || !shareText || !scoreEl) return;
+
+  function translatedModeCopy(mode, field) {
+    const prefix = mode === 'leg_claps' ? 'leg-claps' : 'six-seven';
+    return document.getElementById(`${prefix}-${field}`)?.textContent.trim() || '';
+  }
+
+  function updateShareText() {
+    if (resultCard.hidden) return;
+
+    const mode = app.dataset.gameMode === 'leg_claps' ? 'leg_claps' : 'six_seven';
+    const title = translatedModeCopy(mode, 'title');
+    const resultUnit = translatedModeCopy(mode, 'result-unit');
+    const score = Number(scoreEl.textContent || 0);
+    const blocks = score > 0
+      ? `${'🟩'.repeat(Math.min(score, 67))}${score > 67 ? ` +${score - 67}` : ''}`
+      : '⬜';
+
+    const pageUrl = app.dataset.rivalName
+      ? new URL(window.location.href)
+      : new URL('/67/counter/', window.location.origin);
+    pageUrl.searchParams.set('mode', mode);
+
+    const rival = app.dataset.rivalName
+      ? ` · 🆚 ${app.dataset.rivalName} ${Number(app.dataset.rivalScore || 0)}`
+      : '';
+
+    shareText.value = `${title} — ${score} ${resultUnit}${rival}\n${blocks}\n${pageUrl.href}`;
+  }
+
+  new MutationObserver(updateShareText).observe(resultCard, {
+    attributes: true,
+    attributeFilter: ['hidden'],
+  });
+
+  document.getElementById('copy-counter-share')?.addEventListener('pointerdown', updateShareText, { capture: true });
+})();

--- a/brainrot/static/brainrot/gesture_engine.js
+++ b/brainrot/static/brainrot/gesture_engine.js
@@ -1,3 +1,7 @@
+if (typeof document !== 'undefined') {
+  import('./counter_share_locale.js');
+}
+
 export const GAME_MODES = Object.freeze({
   SIX_SEVEN: 'six_seven',
   LEG_CLAPS: 'leg_claps',

--- a/brainrot/static/brainrot/hof_detail.js
+++ b/brainrot/static/brainrot/hof_detail.js
@@ -11,11 +11,12 @@ if (detail) {
   const blocks = score > 0
     ? `${'🟩'.repeat(Math.min(score, 20))}${score > 20 ? ` +${score - 20}` : ''}`
     : '⬜';
-  const headline = isLegClaps
+  const fallbackHeadline = isLegClaps
     ? `${detail.dataset.username} made ${score} Tung Tung Leg Claps in 20 seconds! 🥒`
     : `${detail.dataset.username} made ${score} 6️⃣7️⃣ moves in 20 seconds! 🔥`;
-  const experiment = isLegClaps ? 'TUNG TUNG LEG CLAPS · 酸黄瓜舞计数' : 'SIX SEVEN!';
-  const text = `${headline}\n${blocks}\n${experiment}\nWatch the run and try to beat it!\n${url}`;
+  // This sentence is already translated by Django in the visible page copy.
+  const headline = detail.querySelector('.pb-2 .fw-bold')?.textContent.trim() || fallbackHeadline;
+  const text = `${headline}\n${blocks}\n${url}`;
   shareText.value = text;
 
   async function copyShareMessage() {
@@ -41,7 +42,7 @@ if (detail) {
   shareButton.addEventListener('click', async () => {
     if (navigator.share) {
       try {
-        await navigator.share({ title: isLegClaps ? 'Tung Tung Leg Claps Hall of Fame' : '67 Hall of Fame', text });
+        await navigator.share({ title: document.title, text });
         status.textContent = tr('Result launched into the world! 🚀');
         return;
       } catch (error) {


### PR DESCRIPTION
## What changed

- Counter result sharing now reuses the already-translated game title and result unit rendered by Django, so English stays fully English and Chinese uses the Chinese page copy.
- Hall of Fame sharing now reuses the already-translated visible result sentence instead of maintaining a separate hard-coded bilingual string in JavaScript.
- Removed the English HOF share line that mixed `TUNG TUNG LEG CLAPS` with `酸黄瓜舞计数`.
- Native share titles now use the localized document title.

No backend, counting, recording, leaderboard, or upload logic changed. No new translation catalog entries or `compilemessages` step are required.