### PR TITLE
Export counted videos as MP4

### DIFF
--- a/brainrot/static/brainrot/counter_share_locale.js
+++ b/brainrot/static/brainrot/counter_share_locale.js
@@ -1,3 +1,5 @@
+import { installMp4Download } from './mp4_download.js';
+
 (() => {
   const app = document.getElementById('counter-app');
   const resultCard = document.getElementById('counter-result');
@@ -39,4 +41,11 @@
   });
 
   document.getElementById('copy-counter-share')?.addEventListener('pointerdown', updateShareText, { capture: true });
+
+  installMp4Download(document.getElementById('download-recording'), {
+    onError(error) {
+      const errorNode = document.getElementById('counter-error');
+      if (errorNode) errorNode.textContent = `MP4 download failed: ${error.message}`;
+    },
+  });
 })();

--- a/brainrot/static/brainrot/hof_detail.js
+++ b/brainrot/static/brainrot/hof_detail.js
@@ -19,6 +19,22 @@ if (detail) {
   const text = `${headline}\n${blocks}\n${url}`;
   shareText.value = text;
 
+  import('./mp4_download.js').then(({ installMp4Download }) => {
+    const downloadButton = detail.querySelector('a[href*="?download=1"]');
+    const safeName = detail.dataset.username.replace(/[^a-z0-9_-]+/gi, '-').replace(/^-+|-+$/g, '') || 'run';
+    installMp4Download(downloadButton, {
+      filename: `${isLegClaps ? 'tung-tung-leg-claps' : '67'}-${safeName}-${score}.webm`,
+      onStatus(message) {
+        status.textContent = message;
+      },
+      onError(error) {
+        status.textContent = `MP4 download failed: ${error.message}`;
+      },
+    });
+  }).catch((error) => {
+    console.error('Could not initialise MP4 downloads.', error);
+  });
+
   async function copyShareMessage() {
     try {
       if (navigator.clipboard?.writeText && window.isSecureContext) {

--- a/brainrot/static/brainrot/hof_detail.js
+++ b/brainrot/static/brainrot/hof_detail.js
@@ -1,3 +1,5 @@
+import { installMp4Download } from './mp4_download.js';
+
 const detail = document.getElementById('hof-detail');
 if (detail) {
   const tr = (message) => typeof gettext === 'function' ? gettext(message) : message;
@@ -17,25 +19,22 @@ if (detail) {
   // This sentence is already translated by Django in the visible page copy.
   const headline = detail.querySelector('.pb-2 .fw-bold')?.textContent.trim() || fallbackHeadline;
   const text = `${headline}\n${blocks}\n${url}`;
-  shareText.value = text;
+  if (shareText) shareText.value = text;
 
-  import('./mp4_download.js').then(({ installMp4Download }) => {
-    const downloadButton = detail.querySelector('a[href*="?download=1"]');
-    const safeName = detail.dataset.username.replace(/[^a-z0-9_-]+/gi, '-').replace(/^-+|-+$/g, '') || 'run';
-    installMp4Download(downloadButton, {
-      filename: `${isLegClaps ? 'tung-tung-leg-claps' : '67'}-${safeName}-${score}.webm`,
-      onStatus(message) {
-        status.textContent = message;
-      },
-      onError(error) {
-        status.textContent = `MP4 download failed: ${error.message}`;
-      },
-    });
-  }).catch((error) => {
-    console.error('Could not initialise MP4 downloads.', error);
+  const downloadButton = detail.querySelector('a[href*="?download=1"]');
+  const safeName = detail.dataset.username.replace(/[^a-z0-9_-]+/gi, '-').replace(/^-+|-+$/g, '') || 'run';
+  installMp4Download(downloadButton, {
+    filename: `${isLegClaps ? 'tung-tung-leg-claps' : '67'}-${safeName}-${score}.webm`,
+    onStatus(message) {
+      if (status) status.textContent = message;
+    },
+    onError(error) {
+      if (status) status.textContent = `MP4 download failed: ${error.message}`;
+    },
   });
 
   async function copyShareMessage() {
+    if (!shareText || !copyButton) return;
     try {
       if (navigator.clipboard?.writeText && window.isSecureContext) {
         await navigator.clipboard.writeText(text);
@@ -45,21 +44,23 @@ if (detail) {
         if (!document.execCommand('copy')) throw new Error('Copy command was rejected.');
       }
       copyButton.textContent = tr('Copied! 🎉');
-      status.textContent = isLegClaps
-        ? tr('Full result copied! The knee evidence is ready for deployment.')
-        : tr('Full result copied! The 6️⃣7️⃣ evidence is ready for deployment.');
+      if (status) {
+        status.textContent = isLegClaps
+          ? tr('Full result copied! The knee evidence is ready for deployment.')
+          : tr('Full result copied! The 6️⃣7️⃣ evidence is ready for deployment.');
+      }
     } catch (error) {
       shareText.select();
-      status.textContent = tr('Automatic copy failed. Select the message and copy it manually.');
+      if (status) status.textContent = tr('Automatic copy failed. Select the message and copy it manually.');
     }
     window.setTimeout(() => { copyButton.textContent = tr('Copy share message'); }, 1500);
   }
 
-  shareButton.addEventListener('click', async () => {
+  shareButton?.addEventListener('click', async () => {
     if (navigator.share) {
       try {
         await navigator.share({ title: document.title, text });
-        status.textContent = tr('Result launched into the world! 🚀');
+        if (status) status.textContent = tr('Result launched into the world! 🚀');
         return;
       } catch (error) {
         if (error.name === 'AbortError') return;
@@ -67,5 +68,5 @@ if (detail) {
     }
     await copyShareMessage();
   });
-  copyButton.addEventListener('click', copyShareMessage);
+  copyButton?.addEventListener('click', copyShareMessage);
 }

--- a/brainrot/static/brainrot/mp4_download.js
+++ b/brainrot/static/brainrot/mp4_download.js
@@ -1,0 +1,120 @@
+const MEDIABUNNY_URL = 'https://cdn.jsdelivr.net/npm/mediabunny@1.52.2/dist/bundles/mediabunny.min.mjs';
+let mediabunnyPromise = null;
+
+function loadMediabunny() {
+  if (!mediabunnyPromise) mediabunnyPromise = import(MEDIABUNNY_URL);
+  return mediabunnyPromise;
+}
+
+function clampProgress(value) {
+  return Math.max(0, Math.min(1, Number(value) || 0));
+}
+
+function mp4Filename(filename = 'counted-video') {
+  return `${filename.replace(/\.(?:webm|mp4)$/i, '')}.mp4`;
+}
+
+function isMp4(blob) {
+  return (blob.type || '').toLowerCase().split(';')[0] === 'video/mp4';
+}
+
+export async function convertVideoToMp4(blob, onProgress = () => {}) {
+  if (!(blob instanceof Blob)) throw new TypeError('Expected a video Blob.');
+  if (isMp4(blob)) return blob;
+
+  const {
+    ALL_FORMATS,
+    BlobSource,
+    BufferTarget,
+    Conversion,
+    Input,
+    Mp4OutputFormat,
+    Output,
+  } = await loadMediabunny();
+
+  const input = new Input({
+    formats: ALL_FORMATS,
+    source: new BlobSource(blob),
+  });
+  const target = new BufferTarget();
+  const output = new Output({
+    format: new Mp4OutputFormat({ fastStart: 'in-memory' }),
+    target,
+  });
+
+  try {
+    const conversion = await Conversion.init({
+      input,
+      output,
+      video: {
+        codec: 'avc',
+        bitrate: 1_600_000,
+        keyFrameInterval: 2,
+      },
+      audio: { discard: true },
+    });
+    if (!conversion.isValid) {
+      throw new Error('This browser cannot convert this recording to MP4.');
+    }
+    conversion.onProgress = (progress) => onProgress(clampProgress(progress));
+    await conversion.execute();
+    if (!target.buffer) throw new Error('MP4 conversion completed without output data.');
+    onProgress(1);
+    return new Blob([target.buffer], { type: 'video/mp4' });
+  } finally {
+    await input.dispose?.();
+  }
+}
+
+function triggerDownload(blob, filename) {
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = mp4Filename(filename);
+  link.hidden = true;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  window.setTimeout(() => URL.revokeObjectURL(url), 30_000);
+}
+
+export function installMp4Download(anchor, options = {}) {
+  if (!anchor || anchor.dataset.mp4DownloadBound === 'true') return;
+  anchor.dataset.mp4DownloadBound = 'true';
+
+  anchor.addEventListener('click', async (event) => {
+    const href = anchor.href;
+    if (!href || anchor.getAttribute('aria-busy') === 'true') return;
+    event.preventDefault();
+
+    const originalText = anchor.textContent;
+    const originalDownload = anchor.getAttribute('download') || options.filename || 'counted-video.webm';
+    const setBusyLabel = (progress = null) => {
+      anchor.textContent = progress === null ? 'MP4…' : `MP4… ${Math.round(progress * 100)}%`;
+    };
+
+    anchor.setAttribute('aria-busy', 'true');
+    anchor.classList.add('disabled');
+    setBusyLabel();
+    options.onStatus?.('Preparing MP4…');
+
+    try {
+      const response = await fetch(href, { credentials: 'same-origin' });
+      if (!response.ok) throw new Error(`Could not read the video (HTTP ${response.status}).`);
+      const sourceBlob = await response.blob();
+      const mp4Blob = await convertVideoToMp4(sourceBlob, (progress) => {
+        setBusyLabel(progress);
+        options.onProgress?.(progress);
+      });
+      triggerDownload(mp4Blob, originalDownload);
+      options.onStatus?.('MP4 ready.');
+    } catch (error) {
+      console.error('MP4 download failed.', error);
+      options.onError?.(error);
+    } finally {
+      anchor.textContent = originalText;
+      anchor.classList.remove('disabled');
+      anchor.removeAttribute('aria-busy');
+    }
+  });
+}

--- a/brainrot/static/brainrot/mp4_download.js
+++ b/brainrot/static/brainrot/mp4_download.js
@@ -18,10 +18,7 @@ function isMp4(blob) {
   return (blob.type || '').toLowerCase().split(';')[0] === 'video/mp4';
 }
 
-export async function convertVideoToMp4(blob, onProgress = () => {}) {
-  if (!(blob instanceof Blob)) throw new TypeError('Expected a video Blob.');
-  if (isMp4(blob)) return blob;
-
+async function runConversion(blob, library, videoOptions, onProgress) {
   const {
     ALL_FORMATS,
     BlobSource,
@@ -30,7 +27,7 @@ export async function convertVideoToMp4(blob, onProgress = () => {}) {
     Input,
     Mp4OutputFormat,
     Output,
-  } = await loadMediabunny();
+  } = library;
 
   const input = new Input({
     formats: ALL_FORMATS,
@@ -46,23 +43,53 @@ export async function convertVideoToMp4(blob, onProgress = () => {}) {
     const conversion = await Conversion.init({
       input,
       output,
-      video: {
-        codec: 'avc',
-        bitrate: 1_600_000,
-        keyFrameInterval: 2,
-      },
+      video: videoOptions,
       audio: { discard: true },
     });
     if (!conversion.isValid) {
-      throw new Error('This browser cannot convert this recording to MP4.');
+      const reasons = conversion.discardedTracks.map(({ reason }) => reason).join(', ');
+      throw new Error(reasons || 'no compatible video encoder');
     }
     conversion.onProgress = (progress) => onProgress(clampProgress(progress));
     await conversion.execute();
-    if (!target.buffer) throw new Error('MP4 conversion completed without output data.');
-    onProgress(1);
+    if (!target.buffer) throw new Error('conversion completed without output data');
     return new Blob([target.buffer], { type: 'video/mp4' });
   } finally {
-    await input.dispose?.();
+    input.dispose();
+  }
+}
+
+export async function convertVideoToMp4(blob, onProgress = () => {}) {
+  if (!(blob instanceof Blob)) throw new TypeError('Expected a video Blob.');
+  if (isMp4(blob)) {
+    onProgress(1);
+    return blob;
+  }
+
+  const library = await loadMediabunny();
+  const avcOptions = {
+    codec: 'avc',
+    bitrate: 1_600_000,
+    keyFrameInterval: 2,
+  };
+
+  try {
+    const mp4 = await runConversion(blob, library, avcOptions, onProgress);
+    onProgress(1);
+    return mp4;
+  } catch (avcError) {
+    console.warn('H.264 MP4 conversion unavailable; trying the browser\'s best MP4 codec.', avcError);
+  }
+
+  try {
+    const mp4 = await runConversion(blob, library, {
+      bitrate: 1_600_000,
+      keyFrameInterval: 2,
+    }, onProgress);
+    onProgress(1);
+    return mp4;
+  } catch (fallbackError) {
+    throw new Error(`This browser cannot convert this recording to MP4: ${fallbackError.message}`);
   }
 }
 

--- a/brainrot/templates/brainrot/hall_of_fame_detail.html
+++ b/brainrot/templates/brainrot/hall_of_fame_detail.html
@@ -76,8 +76,6 @@
     </div>
   </div>
 </main>
-{% if entry.visibility == 'public' %}
 <script src="{% url 'brainrot:javascript_catalog' %}"></script>
-<script src="{% static 'brainrot/hof_detail.js' %}?v=20260817.2" defer></script>
-{% endif %}
+<script type="module" src="{% static 'brainrot/hof_detail.js' %}"></script>
 {% endblock %}

--- a/brainrot/templates/brainrot/hall_of_fame_detail.html
+++ b/brainrot/templates/brainrot/hall_of_fame_detail.html
@@ -77,5 +77,5 @@
   </div>
 </main>
 <script src="{% url 'brainrot:javascript_catalog' %}"></script>
-<script type="module" src="{% static 'brainrot/hof_detail.js' %}"></script>
+<script type="module" src="{% static 'brainrot/hof_detail.js' %}?v=20260817.2"></script>
 {% endblock %}


### PR DESCRIPTION
## What changed

- Kept the existing recording, upload, validation, storage, and backend video pipeline unchanged.
- Added a frontend-only MP4 export layer for the post-run `Download counted video` button.
- Existing MP4 blobs are downloaded directly without transcoding.
- WebM recordings are converted in the browser to MP4 only when the user clicks download.
- The converter lazily loads pinned Mediabunny `1.52.2`, so normal gameplay and pose detection do not pay the conversion-library cost.
- MP4 conversion prefers H.264/AVC for compatibility, then falls back to the browser's best codec that can be encoded into an MP4 container.
- Hall of Fame downloads use the same MP4 exporter, including private/hidden entries visible to their owner.
- Converted downloads always receive a `.mp4` filename.

## Deliberately unchanged

- `counter.js` recorder/upload behavior
- `gesture_engine.js` and all 67 / Tung Tung counting logic
- Django models, views, validators, migrations, and stored videos
- Existing Hall of Fame video files remain in their original format on the server

## Validation

- `node --check` passed for the new MP4 module and both modified frontend modules.
- Direct MP4 passthrough was exercised locally and returns the original MP4 Blob without loading the converter.
- The branch diff contains only frontend/static/template files; no backend or detector files changed.
- Actual WebM -> MP4 transcoding depends on browser WebCodecs support and cannot be integration-tested in this non-browser tool environment, so it should get one real Firefox/Chrome download smoke test after deployment.