### PR TITLE
Add local Six Seven Voice Speedrun

### DIFF
--- a/brainrot/js_tests/voice_engine.test.mjs
+++ b/brainrot/js_tests/voice_engine.test.mjs
@@ -10,22 +10,26 @@ const { countSixSevenPhrases, normaliseVoiceTranscript } = await import(
   `data:text/javascript;base64,${Buffer.from(source).toString('base64')}`
 );
 
-test('normalises punctuation without guessing fuzzy speech', () => {
-  assert.equal(normaliseVoiceTranscript('Six, seven! SIX-seven.'), 'six seven six seven');
+test('normalises local recogniser tokens without fuzzy guessing', () => {
+  assert.equal(normaliseVoiceTranscript('Six, seven! [unk] SIX-seven.'), 'six seven [unk] six seven');
 });
 
 test('counts explicit repeated six seven pairs', () => {
   assert.equal(countSixSevenPhrases('six seven six seven six seven'), 3);
 });
 
-test('accepts digit normalisation produced by speech recognisers', () => {
-  assert.equal(countSixSevenPhrases('6 7 67 six 7'), 3);
+test('unknown speech breaks a pair', () => {
+  assert.equal(countSixSevenPhrases('six [unk] seven six seven'), 1);
 });
 
-test('does not count sixty seven, fused words, or incomplete pairs', () => {
-  assert.equal(countSixSevenPhrases('sixty seven sixseven six six'), 0);
+test('does not count numbers, sixty seven, fused words, or incomplete pairs', () => {
+  assert.equal(countSixSevenPhrases('6 7 67 sixty seven sixseven six'), 0);
 });
 
 test('greedily counts only complete adjacent pairs', () => {
   assert.equal(countSixSevenPhrases('seven six seven six six seven seven'), 2);
+});
+
+test('extra six tokens do not manufacture an extra pair', () => {
+  assert.equal(countSixSevenPhrases('six six seven six seven'), 2);
 });

--- a/brainrot/js_tests/voice_engine.test.mjs
+++ b/brainrot/js_tests/voice_engine.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const source = await readFile(
+  new URL('../static/brainrot/voice_engine.js', import.meta.url),
+  'utf8',
+);
+const { countSixSevenPhrases, normaliseVoiceTranscript } = await import(
+  `data:text/javascript;base64,${Buffer.from(source).toString('base64')}`
+);
+
+test('normalises punctuation without guessing fuzzy speech', () => {
+  assert.equal(normaliseVoiceTranscript('Six, seven! SIX-seven.'), 'six seven six seven');
+});
+
+test('counts explicit repeated six seven pairs', () => {
+  assert.equal(countSixSevenPhrases('six seven six seven six seven'), 3);
+});
+
+test('accepts digit normalisation produced by speech recognisers', () => {
+  assert.equal(countSixSevenPhrases('6 7 67 six 7'), 3);
+});
+
+test('does not count sixty seven, fused words, or incomplete pairs', () => {
+  assert.equal(countSixSevenPhrases('sixty seven sixseven six six'), 0);
+});
+
+test('greedily counts only complete adjacent pairs', () => {
+  assert.equal(countSixSevenPhrases('seven six seven six six seven seven'), 2);
+});

--- a/brainrot/migrations/0006_alter_halloffameentry_game_mode.py
+++ b/brainrot/migrations/0006_alter_halloffameentry_game_mode.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('brainrot', '0005_halloffameentry_game_mode'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='halloffameentry',
+            name='game_mode',
+            field=models.CharField(
+                choices=[
+                    ('six_seven', '67 Counter'),
+                    ('leg_claps', 'Tung Tung Leg Claps'),
+                    ('voice_67', 'Six Seven Voice Speedrun'),
+                ],
+                default='six_seven',
+                max_length=16,
+            ),
+        ),
+    ]

--- a/brainrot/models.py
+++ b/brainrot/models.py
@@ -16,6 +16,7 @@ class HallOfFameEntry(models.Model):
     class GameMode(models.TextChoices):
         SIX_SEVEN = 'six_seven', _('67 Counter')
         LEG_CLAPS = 'leg_claps', _('Tung Tung Leg Claps')
+        VOICE_67 = 'voice_67', _('Six Seven Voice Speedrun')
 
     class Visibility(models.TextChoices):
         PUBLIC = 'public', _('Public')

--- a/brainrot/static/brainrot/hof_detail.js
+++ b/brainrot/static/brainrot/hof_detail.js
@@ -10,12 +10,15 @@ if (detail) {
   const url = detail.dataset.entryUrl;
   const score = Number(detail.dataset.score);
   const isLegClaps = detail.dataset.gameMode === 'leg_claps';
+  const isVoice = detail.dataset.gameMode === 'voice_67';
   const blocks = score > 0
     ? `${'🟩'.repeat(Math.min(score, 20))}${score > 20 ? ` +${score - 20}` : ''}`
     : '⬜';
   const fallbackHeadline = isLegClaps
     ? `${detail.dataset.username} made ${score} Tung Tung Leg Claps in 20 seconds! 🥒`
-    : `${detail.dataset.username} made ${score} 6️⃣7️⃣ moves in 20 seconds! 🔥`;
+    : isVoice
+      ? `${detail.dataset.username} clearly said “six seven” ${score} times in 20 seconds! 🗣️`
+      : `${detail.dataset.username} made ${score} 6️⃣7️⃣ moves in 20 seconds! 🔥`;
   // This sentence is already translated by Django in the visible page copy.
   const headline = detail.querySelector('.pb-2 .fw-bold')?.textContent.trim() || fallbackHeadline;
   const text = `${headline}\n${blocks}\n${url}`;
@@ -23,8 +26,9 @@ if (detail) {
 
   const downloadButton = detail.querySelector('a[href*="?download=1"]');
   const safeName = detail.dataset.username.replace(/[^a-z0-9_-]+/gi, '-').replace(/^-+|-+$/g, '') || 'run';
+  const downloadSlug = isLegClaps ? 'tung-tung-leg-claps' : isVoice ? 'six-seven-voice' : '67';
   installMp4Download(downloadButton, {
-    filename: `${isLegClaps ? 'tung-tung-leg-claps' : '67'}-${safeName}-${score}.webm`,
+    filename: `${downloadSlug}-${safeName}-${score}.webm`,
     onStatus(message) {
       if (status) status.textContent = message;
     },
@@ -47,7 +51,9 @@ if (detail) {
       if (status) {
         status.textContent = isLegClaps
           ? tr('Full result copied! The knee evidence is ready for deployment.')
-          : tr('Full result copied! The 6️⃣7️⃣ evidence is ready for deployment.');
+          : isVoice
+            ? tr('Full result copied! The voice evidence is ready for deployment.')
+            : tr('Full result copied! The 6️⃣7️⃣ evidence is ready for deployment.');
       }
     } catch (error) {
       shareText.select();

--- a/brainrot/static/brainrot/mp4_download.js
+++ b/brainrot/static/brainrot/mp4_download.js
@@ -44,11 +44,10 @@ async function runConversion(blob, library, videoOptions, onProgress) {
       input,
       output,
       video: videoOptions,
-      audio: { discard: true },
     });
     if (!conversion.isValid) {
       const reasons = conversion.discardedTracks.map(({ reason }) => reason).join(', ');
-      throw new Error(reasons || 'no compatible video encoder');
+      throw new Error(reasons || 'no compatible MP4 codec');
     }
     conversion.onProgress = (progress) => onProgress(clampProgress(progress));
     await conversion.execute();

--- a/brainrot/static/brainrot/voice_counter.js
+++ b/brainrot/static/brainrot/voice_counter.js
@@ -1,10 +1,14 @@
 import { installMp4Download } from './mp4_download.js';
 import { countSixSevenPhrases } from './voice_engine.js';
+import {
+  SixSevenLocalRecognizer,
+  loadSixSevenVoiceModel,
+  releaseSixSevenVoiceModel,
+} from './voice_vosk.js';
 
 const app = document.getElementById('voice-app');
 if (app) {
   const tr = (message) => typeof gettext === 'function' ? gettext(message) : message;
-  const SpeechRecognitionCtor = window.SpeechRecognition || window.webkitSpeechRecognition || null;
   const GAME_SECONDS = 20;
   const COUNTDOWN_STEP_MS = 1000;
   const GO_DISPLAY_MS = 250;
@@ -48,24 +52,26 @@ if (app) {
   const rivalFinalScore = Number(app.dataset.rivalScore || 0);
 
   let stream = null;
+  let voiceModel = null;
+  let modelLoadPromise = null;
+  let localRecognizer = null;
+  let audioContext = null;
+  let microphoneSource = null;
+  let recognizerNode = null;
+  let silentGain = null;
+  let feedRecognizer = false;
+
   let running = false;
   let countdownActive = false;
-  let finalisingRecognition = false;
+  let finalising = false;
   let runStartedAt = 0;
   let endTime = 0;
   let gameLoop = null;
   let score = 0;
   let eventTimeline = [];
   let rivalTimelineIndex = 0;
-
-  let recognition = null;
-  let recognitionActive = false;
-  let recognitionStopping = false;
-  let recognitionStopResolve = null;
-  let recognitionStopTimer = null;
-  let completedTranscript = [];
-  let sessionFinalTranscript = '';
-  let sessionInterimTranscript = '';
+  let committedSegments = [];
+  let partialSegment = '';
 
   let recorder = null;
   let recordingStream = null;
@@ -94,189 +100,159 @@ if (app) {
     errorEl.textContent = message || '';
   }
 
-  function officialTranscript() {
-    return [...completedTranscript, sessionFinalTranscript].filter(Boolean).join(' ').trim();
+  function recognisedText({ includePartial = true } = {}) {
+    const parts = [...committedSegments];
+    if (includePartial && partialSegment) parts.push(partialSegment);
+    return parts.filter(Boolean).join(' ').trim();
   }
 
-  function updateTranscriptUI() {
-    const finalText = officialTranscript();
-    heardFinal.textContent = finalText || '—';
-    heardInterim.textContent = sessionInterimTranscript ? `… ${sessionInterimTranscript}` : '';
+  function updateRecognitionUI() {
+    heardFinal.textContent = committedSegments.join(' ').trim() || '—';
+    heardInterim.textContent = partialSegment ? `… ${partialSegment}` : '';
   }
 
-  function syncOfficialScore() {
-    const nextScore = countSixSevenPhrases(officialTranscript());
-    if (nextScore > score) {
-      const elapsed = runStartedAt
-        ? Math.min(GAME_SECONDS, Math.max(0, (performance.now() - runStartedAt) / 1000))
-        : 0;
-      while (eventTimeline.length < nextScore) {
-        eventTimeline.push(Number(elapsed.toFixed(3)));
+  function syncScore({ includePartial = true } = {}) {
+    const nextScore = countSixSevenPhrases(recognisedText({ includePartial }));
+    if (nextScore !== score) {
+      if (nextScore < score) {
+        eventTimeline.length = nextScore;
+      } else {
+        const elapsed = runStartedAt
+          ? Math.min(GAME_SECONDS, Math.max(0, (performance.now() - runStartedAt) / 1000))
+          : 0;
+        while (eventTimeline.length < nextScore) {
+          eventTimeline.push(Number(elapsed.toFixed(3)));
+        }
       }
-    }
-    score = nextScore;
-    scoreEl.textContent = String(score);
-  }
-
-  function commitRecognitionSession() {
-    if (sessionFinalTranscript.trim()) completedTranscript.push(sessionFinalTranscript.trim());
-    sessionFinalTranscript = '';
-    sessionInterimTranscript = '';
-    updateTranscriptUI();
-    syncOfficialScore();
-  }
-
-  function createRecognition() {
-    const instance = new SpeechRecognitionCtor();
-    instance.lang = 'en-AU';
-    instance.continuous = true;
-    instance.interimResults = true;
-    instance.maxAlternatives = 1;
-
-    // Newer implementations can bias the recogniser toward the literal phrase.
-    // This is optional; scoring never depends on this experimental API existing.
-    if ('phrases' in instance && window.SpeechRecognitionPhrase) {
-      try {
-        instance.phrases = [new window.SpeechRecognitionPhrase('six seven', 6)];
-      } catch (error) {
-        console.debug('Speech phrase bias is unavailable.', error);
-      }
-    }
-
-    instance.addEventListener('start', () => {
-      recognitionActive = true;
-      if (running) setStatus(tr('Listening — say six seven'), 'ready');
-    });
-
-    instance.addEventListener('result', (event) => {
-      let finalText = '';
-      let interimText = '';
-      for (let index = 0; index < event.results.length; index += 1) {
-        const result = event.results[index];
-        const transcript = result[0]?.transcript?.trim() || '';
-        if (!transcript) continue;
-        if (result.isFinal) finalText += `${transcript} `;
-        else interimText += `${transcript} `;
-      }
-      sessionFinalTranscript = finalText.trim();
-      sessionInterimTranscript = interimText.trim();
-      updateTranscriptUI();
-      if (running || finalisingRecognition) syncOfficialScore();
-    });
-
-    instance.addEventListener('error', (event) => {
-      if (event.error === 'aborted' && recognitionStopping) return;
-      if (event.error === 'no-speech') {
-        if (running) setStatus(tr('Still listening — speak clearly'), 'busy');
-        return;
-      }
-      showError(`Speech recognition: ${event.error || 'unknown error'}`);
-    });
-
-    instance.addEventListener('end', () => {
-      recognitionActive = false;
-      commitRecognitionSession();
-
-      if (recognitionStopping) {
-        recognitionStopping = false;
-        if (recognitionStopTimer) window.clearTimeout(recognitionStopTimer);
-        recognitionStopTimer = null;
-        const resolve = recognitionStopResolve;
-        recognitionStopResolve = null;
-        resolve?.();
-        return;
-      }
-
-      if (running && performance.now() < endTime) {
-        window.setTimeout(() => {
-          if (running && !recognitionActive && !recognitionStopping) startRecognitionSession();
-        }, 60);
-      }
-    });
-
-    return instance;
-  }
-
-  function startRecognitionSession() {
-    if (!SpeechRecognitionCtor || recognitionActive || recognitionStopping || !running) return;
-    recognition = createRecognition();
-    sessionFinalTranscript = '';
-    sessionInterimTranscript = '';
-    try {
-      recognition.start();
-    } catch (error) {
-      showError(`Could not start speech recognition: ${error.message}`);
+      score = nextScore;
+      scoreEl.textContent = String(score);
     }
   }
 
-  function stopRecognition() {
-    finalisingRecognition = true;
-    return new Promise((resolve) => {
-      if (!recognition || !recognitionActive) {
-        commitRecognitionSession();
-        finalisingRecognition = false;
-        resolve();
-        return;
-      }
+  function handlePartial(text) {
+    if (!running && !finalising) return;
+    partialSegment = text || '';
+    updateRecognitionUI();
+    syncScore({ includePartial: true });
+  }
 
-      recognitionStopping = true;
-      recognitionStopResolve = () => {
-        finalisingRecognition = false;
-        resolve();
-      };
-      try {
-        recognition.stop();
-      } catch (error) {
-        console.warn('Speech recognition stop failed.', error);
-        recognitionStopping = false;
-        commitRecognitionSession();
-        recognitionStopResolve = null;
-        finalisingRecognition = false;
-        resolve();
-        return;
-      }
+  function handleResult(text) {
+    if (!running && !finalising) return;
+    if (text) committedSegments.push(text);
+    partialSegment = '';
+    updateRecognitionUI();
+    syncScore({ includePartial: false });
+  }
 
-      recognitionStopTimer = window.setTimeout(() => {
-        try { recognition?.abort(); } catch (error) { console.debug(error); }
-        recognitionActive = false;
-        recognitionStopping = false;
-        commitRecognitionSession();
-        const finish = recognitionStopResolve;
-        recognitionStopResolve = null;
-        recognitionStopTimer = null;
-        finalisingRecognition = false;
-        finish?.();
-      }, 2500);
-    });
+  async function ensureVoiceModel() {
+    if (voiceModel?.ready) return voiceModel;
+    if (!modelLoadPromise) {
+      modelLoadPromise = loadSixSevenVoiceModel((message) => {
+        if (!stream) setStatus(tr(message), 'busy');
+      }).then((model) => {
+        voiceModel = model;
+        if (!stream) setStatus(tr('Local voice model ready — camera and microphone remain off'), 'ready');
+        updateStartAvailability();
+        return model;
+      }).catch((error) => {
+        modelLoadPromise = null;
+        showError(`Local voice model: ${error.message}`);
+        setStatus(tr('Local voice model failed to load'));
+        throw error;
+      });
+    }
+    return modelLoadPromise;
+  }
+
+  function updateStartAvailability() {
+    const ready = Boolean(stream && voiceModel?.ready);
+    startButton.hidden = !stream;
+    startButton.disabled = !ready;
+    startButton.textContent = ready ? tr("I'm ready") : tr('Loading local voice model…');
+    if (stream && !voiceModel?.ready) {
+      setStatus(tr('Camera and microphone ready — loading local voice model'), 'busy');
+    } else if (ready && !running && !countdownActive) {
+      setStatus(tr('Camera, microphone and local voice model ready'), 'ready');
+    }
   }
 
   async function enableVoice() {
     showError('');
-    if (!SpeechRecognitionCtor) {
-      showError(tr('This browser does not expose SpeechRecognition. Try a current browser with Web Speech recognition support.'));
-      return;
-    }
-
     enableButton.disabled = true;
     setStatus(tr('Requesting camera and microphone permission…'), 'busy');
+
+    const modelPromise = ensureVoiceModel();
     try {
       stream = await navigator.mediaDevices.getUserMedia({
-        video: { width: { ideal: 640 }, height: { ideal: 480 }, frameRate: { ideal: 30, max: 30 } },
-        audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
+        video: {
+          width: { ideal: 640 },
+          height: { ideal: 480 },
+          frameRate: { ideal: 30, max: 30 },
+        },
+        audio: {
+          echoCancellation: true,
+          noiseSuppression: true,
+          autoGainControl: true,
+          channelCount: 1,
+        },
       });
       video.srcObject = stream;
       await video.play();
       placeholder.hidden = true;
       enableButton.hidden = true;
-      startButton.hidden = false;
-      startButton.disabled = false;
-      startButton.textContent = tr("I'm ready");
-      setStatus(tr('Camera, microphone and recogniser ready'), 'ready');
+      updateStartAvailability();
+
+      try {
+        await modelPromise;
+      } catch {
+        // ensureVoiceModel already surfaced the useful error; camera/mic can stay enabled for retry.
+      }
+      updateStartAvailability();
     } catch (error) {
       enableButton.disabled = false;
       setStatus(tr('Camera or microphone unavailable'));
       showError(error.message || tr('Allow camera and microphone access, then try again.'));
     }
+  }
+
+  async function ensureAudioPipeline() {
+    if (audioContext) {
+      if (audioContext.state === 'suspended') await audioContext.resume();
+      return;
+    }
+    const AudioContextCtor = window.AudioContext || window.webkitAudioContext;
+    if (!AudioContextCtor) throw new Error('This browser does not support Web Audio.');
+
+    audioContext = new AudioContextCtor();
+    microphoneSource = audioContext.createMediaStreamSource(stream);
+    recognizerNode = audioContext.createScriptProcessor(2048, 1, 1);
+    silentGain = audioContext.createGain();
+    silentGain.gain.value = 0;
+
+    recognizerNode.onaudioprocess = (event) => {
+      if (!feedRecognizer || !localRecognizer) return;
+      try {
+        localRecognizer.acceptWaveform(event.inputBuffer);
+      } catch (error) {
+        showError(`Local voice recognition: ${error.message}`);
+      }
+    };
+
+    microphoneSource.connect(recognizerNode);
+    recognizerNode.connect(silentGain);
+    silentGain.connect(audioContext.destination);
+    if (audioContext.state === 'suspended') await audioContext.resume();
+  }
+
+  function createLocalRecognizer() {
+    localRecognizer?.remove();
+    localRecognizer = new SixSevenLocalRecognizer(voiceModel, audioContext.sampleRate, {
+      onPartial: handlePartial,
+      onResult: handleResult,
+      onError(error) {
+        showError(`Local voice recognition: ${error.message}`);
+      },
+    });
   }
 
   function preferredRecordingType() {
@@ -365,7 +341,10 @@ if (app) {
     recordingStream.addTrack(microphone.clone());
 
     recordingChunks = [];
-    recorder = new MediaRecorder(recordingStream, { mimeType: type, videoBitsPerSecond: 1_600_000 });
+    recorder = new MediaRecorder(recordingStream, {
+      mimeType: type,
+      videoBitsPerSecond: 1_600_000,
+    });
     recorder.addEventListener('dataavailable', (event) => {
       if (event.data.size) recordingChunks.push(event.data);
     });
@@ -426,25 +405,26 @@ if (app) {
   }
 
   async function beginRun() {
-    if (!stream || running || countdownActive) return;
+    if (!stream || !voiceModel?.ready || running || countdownActive || finalising) return;
     showError('');
     resultCard.hidden = true;
     resetButton.hidden = true;
     startButton.hidden = true;
     score = 0;
     eventTimeline = [];
-    completedTranscript = [];
-    sessionFinalTranscript = '';
-    sessionInterimTranscript = '';
+    committedSegments = [];
+    partialSegment = '';
     runStartedAt = 0;
     endTime = 0;
     rivalTimelineIndex = 0;
     scoreEl.textContent = '0';
     timeEl.textContent = GAME_SECONDS.toFixed(1);
-    updateTranscriptUI();
+    updateRecognitionUI();
     if (rivalScoreEl) rivalScoreEl.textContent = '0';
 
     try {
+      await ensureAudioPipeline();
+      createLocalRecognizer();
       if (rivalVideo) {
         rivalVideo.muted = true;
         rivalVideo.currentTime = 0;
@@ -470,30 +450,41 @@ if (app) {
     countdownActive = false;
 
     running = true;
+    feedRecognizer = true;
     runStartedAt = performance.now();
     endTime = runStartedAt + GAME_SECONDS * 1000;
     if (rivalVideo && Math.abs(rivalVideo.currentTime - RECORDING_LEAD_SECONDS) > 0.35) {
       rivalVideo.currentTime = RECORDING_LEAD_SECONDS;
     }
-    startRecognitionSession();
-    setStatus(tr('Listening — say six seven'), 'ready');
+    setStatus(tr('Listening locally — say six seven'), 'ready');
     gameLoop = requestAnimationFrame(updateGameClock);
   }
 
   async function finishRun() {
     if (!running) return;
     running = false;
+    feedRecognizer = false;
+    finalising = true;
     cancelAnimationFrame(gameLoop);
     timeEl.textContent = '0.0';
     rivalVideo?.pause();
     if (rivalScoreEl) rivalScoreEl.textContent = String(rivalFinalScore);
-    setStatus(tr('Time — finalising the recogniser…'), 'busy');
+    setStatus(tr('Time — locking the local model result…'), 'busy');
 
-    await stopRecognition();
-    syncOfficialScore();
-    const blob = await stopRecording();
+    // Stop evidence at the deadline. The worker may take a moment to flush
+    // already-received audio, but no post-deadline microphone samples are fed.
+    const recordingPromise = stopRecording();
+    const finalResultPromise = localRecognizer?.finalise(1500) || Promise.resolve('');
+    const [blob] = await Promise.all([recordingPromise, finalResultPromise]);
 
-    setStatus(tr('Run complete — final recognitions locked'), 'ready');
+    // If the worker timed out without a final event, keep only complete pairs
+    // visible in its last local partial snapshot. No fuzzy reconstruction.
+    syncScore({ includePartial: true });
+    finalising = false;
+    localRecognizer?.remove();
+    localRecognizer = null;
+
+    setStatus(tr('Run complete — local voice result locked'), 'ready');
     resultScore.textContent = String(score);
     resultCopy.textContent = rivalName
       ? score > rivalFinalScore
@@ -542,7 +533,7 @@ if (app) {
       }
       copyShareButton.textContent = tr('Copied! 🎉');
       copyShareStatus.textContent = tr('Result copied.');
-    } catch (error) {
+    } catch {
       copyShareStatus.textContent = tr('Automatic copy failed. Select the text and copy it manually.');
     }
     window.setTimeout(() => { copyShareButton.textContent = tr('Copy to clipboard'); }, 1500);
@@ -562,22 +553,22 @@ if (app) {
 
   function resetRun() {
     discardRecording();
-    try { recognition?.abort(); } catch (error) { console.debug(error); }
-    recognition = null;
-    recognitionActive = false;
-    recognitionStopping = false;
-    finalisingRecognition = false;
+    feedRecognizer = false;
+    localRecognizer?.remove();
+    localRecognizer = null;
+    running = false;
+    countdownActive = false;
+    finalising = false;
     score = 0;
     eventTimeline = [];
-    completedTranscript = [];
-    sessionFinalTranscript = '';
-    sessionInterimTranscript = '';
+    committedSegments = [];
+    partialSegment = '';
     runStartedAt = 0;
     endTime = 0;
     rivalTimelineIndex = 0;
     scoreEl.textContent = '0';
     timeEl.textContent = GAME_SECONDS.toFixed(1);
-    updateTranscriptUI();
+    updateRecognitionUI();
     if (rivalScoreEl) rivalScoreEl.textContent = '0';
     if (rivalVideo) {
       rivalVideo.pause();
@@ -587,10 +578,8 @@ if (app) {
     shareText.value = '';
     copyShareStatus.textContent = '';
     resetButton.hidden = true;
-    startButton.hidden = false;
-    startButton.disabled = !stream;
+    updateStartAvailability();
     showError('');
-    setStatus(tr('Ready for another voice run'), 'ready');
   }
 
   function openPublicationModal() {
@@ -648,7 +637,9 @@ if (app) {
       uploadStatus.textContent = payload.message;
       submitButton.hidden = true;
       if (discardButton) discardButton.hidden = true;
-      window.setTimeout(() => { window.location.href = payload.entry_url || app.dataset.hallUrl; }, 900);
+      window.setTimeout(() => {
+        window.location.href = payload.entry_url || app.dataset.hallUrl;
+      }, 900);
     } catch (error) {
       uploadStatus.textContent = error.message;
       submitButton.disabled = false;
@@ -661,14 +652,6 @@ if (app) {
       showError(`MP4 download failed: ${error.message}`);
     },
   });
-
-  if (!SpeechRecognitionCtor) {
-    enableButton.disabled = true;
-    setStatus(tr('Speech recognition is unavailable in this browser'));
-    showError(tr('This browser does not expose SpeechRecognition. Use a supported browser for Voice Speedrun.'));
-  } else {
-    setStatus(tr('Ready to request camera and microphone'), 'ready');
-  }
 
   enableButton.addEventListener('click', enableVoice);
   startButton.addEventListener('click', beginRun);
@@ -690,4 +673,22 @@ if (app) {
   document.querySelectorAll('[data-close-publication-modal]').forEach((node) => {
     node.addEventListener('click', closePublicationModal);
   });
+
+  window.addEventListener('pagehide', () => {
+    feedRecognizer = false;
+    localRecognizer?.remove();
+    stream?.getTracks().forEach((track) => track.stop());
+    try {
+      recognizerNode?.disconnect();
+      microphoneSource?.disconnect();
+      silentGain?.disconnect();
+      audioContext?.close();
+    } catch (error) {
+      console.debug('Voice audio cleanup failed.', error);
+    }
+    releaseSixSevenVoiceModel();
+  }, { once: true });
+
+  setStatus(tr('Preloading local voice model — camera and microphone remain off'), 'busy');
+  ensureVoiceModel().catch(() => {});
 }

--- a/brainrot/static/brainrot/voice_counter.js
+++ b/brainrot/static/brainrot/voice_counter.js
@@ -1,0 +1,693 @@
+import { installMp4Download } from './mp4_download.js';
+import { countSixSevenPhrases } from './voice_engine.js';
+
+const app = document.getElementById('voice-app');
+if (app) {
+  const tr = (message) => typeof gettext === 'function' ? gettext(message) : message;
+  const SpeechRecognitionCtor = window.SpeechRecognition || window.webkitSpeechRecognition || null;
+  const GAME_SECONDS = 20;
+  const COUNTDOWN_STEP_MS = 1000;
+  const GO_DISPLAY_MS = 250;
+  const RECORDING_LEAD_SECONDS = 3 + GO_DISPLAY_MS / 1000;
+
+  const video = document.getElementById('camera');
+  const placeholder = document.getElementById('camera-placeholder');
+  const countdownEl = document.getElementById('countdown');
+  const livePill = document.getElementById('live-pill');
+  const status = document.getElementById('voice-status');
+  const errorEl = document.getElementById('voice-error');
+  const scoreEl = document.getElementById('score');
+  const timeEl = document.getElementById('counter-time');
+  const heardFinal = document.getElementById('heard-final');
+  const heardInterim = document.getElementById('heard-interim');
+  const enableButton = document.getElementById('enable-voice');
+  const startButton = document.getElementById('start-run');
+  const resetButton = document.getElementById('reset-run');
+  const resultCard = document.getElementById('voice-result');
+  const resultScore = document.getElementById('result-score');
+  const resultCopy = document.getElementById('result-copy');
+  const shareText = document.getElementById('voice-share-text');
+  const copyShareButton = document.getElementById('copy-voice-share');
+  const copyShareStatus = document.getElementById('copy-voice-status');
+  const recordingReview = document.getElementById('recording-review');
+  const recordingPreview = document.getElementById('recording-preview');
+  const recordingDownload = document.getElementById('download-recording');
+  const submitButton = document.getElementById('submit-hof');
+  const displayNameInput = document.getElementById('hof-display-name');
+  const discardButton = document.getElementById('discard-recording');
+  const uploadStatus = document.getElementById('upload-status');
+  const publicationModal = document.getElementById('publication-modal');
+  const publicationConsent = document.getElementById('publication-consent');
+  const confirmPublication = document.getElementById('confirm-publication');
+  const rivalVideo = document.getElementById('rival-video');
+  const rivalScoreEl = document.getElementById('rival-score');
+  const rivalTimelineNode = document.getElementById('rival-event-timeline');
+
+  const rivalTimeline = rivalTimelineNode ? JSON.parse(rivalTimelineNode.textContent) : [];
+  const rivalName = app.dataset.rivalName || '';
+  const rivalFinalScore = Number(app.dataset.rivalScore || 0);
+
+  let stream = null;
+  let running = false;
+  let countdownActive = false;
+  let finalisingRecognition = false;
+  let runStartedAt = 0;
+  let endTime = 0;
+  let gameLoop = null;
+  let score = 0;
+  let eventTimeline = [];
+  let rivalTimelineIndex = 0;
+
+  let recognition = null;
+  let recognitionActive = false;
+  let recognitionStopping = false;
+  let recognitionStopResolve = null;
+  let recognitionStopTimer = null;
+  let completedTranscript = [];
+  let sessionFinalTranscript = '';
+  let sessionInterimTranscript = '';
+
+  let recorder = null;
+  let recordingStream = null;
+  let recordingCanvas = null;
+  let recordingContext = null;
+  let recordingFrame = null;
+  let recordingChunks = [];
+  let recordingBlob = null;
+  let recordingUrl = null;
+
+  function delay(milliseconds) {
+    return new Promise((resolve) => window.setTimeout(resolve, milliseconds));
+  }
+
+  function csrfToken() {
+    const match = document.cookie.match(/(?:^|; )csrftoken=([^;]+)/);
+    return match ? decodeURIComponent(match[1]) : '';
+  }
+
+  function setStatus(message, state = '') {
+    status.className = `detector-status ${state}`;
+    status.querySelector('span:last-child').textContent = message;
+  }
+
+  function showError(message) {
+    errorEl.textContent = message || '';
+  }
+
+  function officialTranscript() {
+    return [...completedTranscript, sessionFinalTranscript].filter(Boolean).join(' ').trim();
+  }
+
+  function updateTranscriptUI() {
+    const finalText = officialTranscript();
+    heardFinal.textContent = finalText || '—';
+    heardInterim.textContent = sessionInterimTranscript ? `… ${sessionInterimTranscript}` : '';
+  }
+
+  function syncOfficialScore() {
+    const nextScore = countSixSevenPhrases(officialTranscript());
+    if (nextScore > score) {
+      const elapsed = runStartedAt
+        ? Math.min(GAME_SECONDS, Math.max(0, (performance.now() - runStartedAt) / 1000))
+        : 0;
+      while (eventTimeline.length < nextScore) {
+        eventTimeline.push(Number(elapsed.toFixed(3)));
+      }
+    }
+    score = nextScore;
+    scoreEl.textContent = String(score);
+  }
+
+  function commitRecognitionSession() {
+    if (sessionFinalTranscript.trim()) completedTranscript.push(sessionFinalTranscript.trim());
+    sessionFinalTranscript = '';
+    sessionInterimTranscript = '';
+    updateTranscriptUI();
+    syncOfficialScore();
+  }
+
+  function createRecognition() {
+    const instance = new SpeechRecognitionCtor();
+    instance.lang = 'en-AU';
+    instance.continuous = true;
+    instance.interimResults = true;
+    instance.maxAlternatives = 1;
+
+    // Newer implementations can bias the recogniser toward the literal phrase.
+    // This is optional; scoring never depends on this experimental API existing.
+    if ('phrases' in instance && window.SpeechRecognitionPhrase) {
+      try {
+        instance.phrases = [new window.SpeechRecognitionPhrase('six seven', 6)];
+      } catch (error) {
+        console.debug('Speech phrase bias is unavailable.', error);
+      }
+    }
+
+    instance.addEventListener('start', () => {
+      recognitionActive = true;
+      if (running) setStatus(tr('Listening — say six seven'), 'ready');
+    });
+
+    instance.addEventListener('result', (event) => {
+      let finalText = '';
+      let interimText = '';
+      for (let index = 0; index < event.results.length; index += 1) {
+        const result = event.results[index];
+        const transcript = result[0]?.transcript?.trim() || '';
+        if (!transcript) continue;
+        if (result.isFinal) finalText += `${transcript} `;
+        else interimText += `${transcript} `;
+      }
+      sessionFinalTranscript = finalText.trim();
+      sessionInterimTranscript = interimText.trim();
+      updateTranscriptUI();
+      if (running || finalisingRecognition) syncOfficialScore();
+    });
+
+    instance.addEventListener('error', (event) => {
+      if (event.error === 'aborted' && recognitionStopping) return;
+      if (event.error === 'no-speech') {
+        if (running) setStatus(tr('Still listening — speak clearly'), 'busy');
+        return;
+      }
+      showError(`Speech recognition: ${event.error || 'unknown error'}`);
+    });
+
+    instance.addEventListener('end', () => {
+      recognitionActive = false;
+      commitRecognitionSession();
+
+      if (recognitionStopping) {
+        recognitionStopping = false;
+        if (recognitionStopTimer) window.clearTimeout(recognitionStopTimer);
+        recognitionStopTimer = null;
+        const resolve = recognitionStopResolve;
+        recognitionStopResolve = null;
+        resolve?.();
+        return;
+      }
+
+      if (running && performance.now() < endTime) {
+        window.setTimeout(() => {
+          if (running && !recognitionActive && !recognitionStopping) startRecognitionSession();
+        }, 60);
+      }
+    });
+
+    return instance;
+  }
+
+  function startRecognitionSession() {
+    if (!SpeechRecognitionCtor || recognitionActive || recognitionStopping || !running) return;
+    recognition = createRecognition();
+    sessionFinalTranscript = '';
+    sessionInterimTranscript = '';
+    try {
+      recognition.start();
+    } catch (error) {
+      showError(`Could not start speech recognition: ${error.message}`);
+    }
+  }
+
+  function stopRecognition() {
+    finalisingRecognition = true;
+    return new Promise((resolve) => {
+      if (!recognition || !recognitionActive) {
+        commitRecognitionSession();
+        finalisingRecognition = false;
+        resolve();
+        return;
+      }
+
+      recognitionStopping = true;
+      recognitionStopResolve = () => {
+        finalisingRecognition = false;
+        resolve();
+      };
+      try {
+        recognition.stop();
+      } catch (error) {
+        console.warn('Speech recognition stop failed.', error);
+        recognitionStopping = false;
+        commitRecognitionSession();
+        recognitionStopResolve = null;
+        finalisingRecognition = false;
+        resolve();
+        return;
+      }
+
+      recognitionStopTimer = window.setTimeout(() => {
+        try { recognition?.abort(); } catch (error) { console.debug(error); }
+        recognitionActive = false;
+        recognitionStopping = false;
+        commitRecognitionSession();
+        const finish = recognitionStopResolve;
+        recognitionStopResolve = null;
+        recognitionStopTimer = null;
+        finalisingRecognition = false;
+        finish?.();
+      }, 2500);
+    });
+  }
+
+  async function enableVoice() {
+    showError('');
+    if (!SpeechRecognitionCtor) {
+      showError(tr('This browser does not expose SpeechRecognition. Try a current browser with Web Speech recognition support.'));
+      return;
+    }
+
+    enableButton.disabled = true;
+    setStatus(tr('Requesting camera and microphone permission…'), 'busy');
+    try {
+      stream = await navigator.mediaDevices.getUserMedia({
+        video: { width: { ideal: 640 }, height: { ideal: 480 }, frameRate: { ideal: 30, max: 30 } },
+        audio: { echoCancellation: true, noiseSuppression: true, autoGainControl: true },
+      });
+      video.srcObject = stream;
+      await video.play();
+      placeholder.hidden = true;
+      enableButton.hidden = true;
+      startButton.hidden = false;
+      startButton.disabled = false;
+      startButton.textContent = tr("I'm ready");
+      setStatus(tr('Camera, microphone and recogniser ready'), 'ready');
+    } catch (error) {
+      enableButton.disabled = false;
+      setStatus(tr('Camera or microphone unavailable'));
+      showError(error.message || tr('Allow camera and microphone access, then try again.'));
+    }
+  }
+
+  function preferredRecordingType() {
+    if (!window.MediaRecorder) return '';
+    const candidates = [
+      'video/webm;codecs=vp8,opus',
+      'video/webm',
+      'video/mp4;codecs=avc1.42E01E,mp4a.40.2',
+      'video/mp4',
+    ];
+    return candidates.find((type) => MediaRecorder.isTypeSupported(type)) || '';
+  }
+
+  function drawRecordingHud() {
+    if (!recordingCanvas || !recordingContext) return;
+    const width = recordingCanvas.width;
+    const height = recordingCanvas.height;
+    const padding = Math.max(14, width * 0.026);
+    const scoreSize = Math.max(34, width * 0.085);
+    const labelSize = Math.max(12, width * 0.024);
+    let time = '20.0';
+    if (runStartedAt) time = Math.max(0, (endTime - performance.now()) / 1000).toFixed(1);
+
+    recordingContext.save();
+    recordingContext.fillStyle = 'rgba(15, 23, 42, .82)';
+    recordingContext.fillRect(padding, padding, scoreSize * 2.25, scoreSize * 1.42);
+    recordingContext.fillStyle = '#d8ff62';
+    recordingContext.font = `900 ${scoreSize}px Inter, Arial, sans-serif`;
+    recordingContext.textBaseline = 'top';
+    recordingContext.fillText(String(score), padding * 1.55, padding * 1.15);
+    recordingContext.fillStyle = '#ffffff';
+    recordingContext.font = `800 ${labelSize}px Inter, Arial, sans-serif`;
+    recordingContext.fillText('VOICE 67', padding * 1.55, padding * 1.15 + scoreSize);
+
+    recordingContext.textAlign = 'right';
+    recordingContext.fillStyle = 'rgba(15, 23, 42, .76)';
+    recordingContext.fillRect(width - padding - scoreSize * 1.75, padding, scoreSize * 1.75, scoreSize * .72);
+    recordingContext.fillStyle = '#ffffff';
+    recordingContext.font = `850 ${scoreSize * .43}px ui-monospace, monospace`;
+    recordingContext.fillText(`${time}s`, width - padding * 1.45, padding * 1.22);
+
+    const countdown = countdownEl.textContent.trim();
+    if (countdownActive && countdown) {
+      recordingContext.textAlign = 'center';
+      recordingContext.textBaseline = 'middle';
+      recordingContext.fillStyle = 'rgba(15, 23, 42, .45)';
+      recordingContext.fillRect(0, height * .31, width, height * .38);
+      recordingContext.fillStyle = '#ffffff';
+      recordingContext.font = `950 ${Math.max(80, height * .3)}px Inter, Arial, sans-serif`;
+      recordingContext.fillText(countdown, width / 2, height / 2);
+    }
+
+    recordingContext.textAlign = 'left';
+    recordingContext.textBaseline = 'alphabetic';
+    recordingContext.fillStyle = 'rgba(15, 23, 42, .72)';
+    recordingContext.fillRect(padding, height - padding - labelSize * 2.1, labelSize * 9.2, labelSize * 2.1);
+    recordingContext.fillStyle = '#ffffff';
+    recordingContext.font = `800 ${labelSize}px Inter, Arial, sans-serif`;
+    recordingContext.fillText('icaijy.com', padding * 1.45, height - padding - labelSize * .55);
+    recordingContext.restore();
+  }
+
+  function startRecording() {
+    const type = preferredRecordingType();
+    if (!type) throw new Error('This browser cannot record a compatible video with microphone audio.');
+
+    recordingCanvas = document.createElement('canvas');
+    recordingCanvas.width = video.videoWidth || 640;
+    recordingCanvas.height = video.videoHeight || 480;
+    recordingContext = recordingCanvas.getContext('2d');
+    if (!recordingContext || !recordingCanvas.captureStream) {
+      throw new Error('This browser cannot create a counted evidence recording.');
+    }
+
+    const drawFrame = () => {
+      if (!recordingCanvas || !recordingContext) return;
+      recordingContext.drawImage(video, 0, 0, recordingCanvas.width, recordingCanvas.height);
+      drawRecordingHud();
+      recordingFrame = requestAnimationFrame(drawFrame);
+    };
+    drawFrame();
+
+    recordingStream = recordingCanvas.captureStream(30);
+    const microphone = stream?.getAudioTracks()[0];
+    if (!microphone) throw new Error('Microphone track disappeared before recording started.');
+    recordingStream.addTrack(microphone.clone());
+
+    recordingChunks = [];
+    recorder = new MediaRecorder(recordingStream, { mimeType: type, videoBitsPerSecond: 1_600_000 });
+    recorder.addEventListener('dataavailable', (event) => {
+      if (event.data.size) recordingChunks.push(event.data);
+    });
+    recorder.start(500);
+    livePill.hidden = false;
+  }
+
+  function stopRecordingPipeline() {
+    if (recordingFrame !== null) cancelAnimationFrame(recordingFrame);
+    recordingFrame = null;
+    recordingStream?.getTracks().forEach((track) => track.stop());
+    recordingStream = null;
+    recordingContext = null;
+    recordingCanvas = null;
+  }
+
+  function stopRecording() {
+    return new Promise((resolve) => {
+      if (!recorder || recorder.state === 'inactive') {
+        recorder = null;
+        recordingChunks = [];
+        stopRecordingPipeline();
+        livePill.hidden = true;
+        resolve(null);
+        return;
+      }
+      recorder.addEventListener('stop', () => {
+        const baseType = (recorder.mimeType || recordingChunks[0]?.type || 'video/webm').split(';')[0];
+        recordingBlob = new Blob(recordingChunks, { type: baseType });
+        recorder = null;
+        recordingChunks = [];
+        stopRecordingPipeline();
+        livePill.hidden = true;
+        resolve(recordingBlob);
+      }, { once: true });
+      recorder.stop();
+    });
+  }
+
+  function updateGameClock() {
+    if (!running) return;
+    const remaining = Math.max(0, (endTime - performance.now()) / 1000);
+    timeEl.textContent = remaining.toFixed(1);
+
+    if (rivalVideo) {
+      const rivalGameTime = Math.max(0, rivalVideo.currentTime - RECORDING_LEAD_SECONDS);
+      while (rivalTimelineIndex < rivalTimeline.length && rivalTimeline[rivalTimelineIndex] <= rivalGameTime) {
+        rivalTimelineIndex += 1;
+      }
+      rivalScoreEl.textContent = String(rivalTimelineIndex);
+    }
+
+    if (remaining <= 0) {
+      finishRun();
+      return;
+    }
+    gameLoop = requestAnimationFrame(updateGameClock);
+  }
+
+  async function beginRun() {
+    if (!stream || running || countdownActive) return;
+    showError('');
+    resultCard.hidden = true;
+    resetButton.hidden = true;
+    startButton.hidden = true;
+    score = 0;
+    eventTimeline = [];
+    completedTranscript = [];
+    sessionFinalTranscript = '';
+    sessionInterimTranscript = '';
+    runStartedAt = 0;
+    endTime = 0;
+    rivalTimelineIndex = 0;
+    scoreEl.textContent = '0';
+    timeEl.textContent = GAME_SECONDS.toFixed(1);
+    updateTranscriptUI();
+    if (rivalScoreEl) rivalScoreEl.textContent = '0';
+
+    try {
+      if (rivalVideo) {
+        rivalVideo.muted = true;
+        rivalVideo.currentTime = 0;
+        await rivalVideo.play();
+      }
+      startRecording();
+    } catch (error) {
+      rivalVideo?.pause();
+      showError(error.message);
+      startButton.hidden = false;
+      return;
+    }
+
+    countdownActive = true;
+    setStatus(tr('Evidence recording started — wait for GO'), 'busy');
+    for (const value of ['3', '2', '1']) {
+      countdownEl.textContent = value;
+      await delay(COUNTDOWN_STEP_MS);
+    }
+    countdownEl.textContent = 'GO';
+    await delay(GO_DISPLAY_MS);
+    countdownEl.textContent = '';
+    countdownActive = false;
+
+    running = true;
+    runStartedAt = performance.now();
+    endTime = runStartedAt + GAME_SECONDS * 1000;
+    if (rivalVideo && Math.abs(rivalVideo.currentTime - RECORDING_LEAD_SECONDS) > 0.35) {
+      rivalVideo.currentTime = RECORDING_LEAD_SECONDS;
+    }
+    startRecognitionSession();
+    setStatus(tr('Listening — say six seven'), 'ready');
+    gameLoop = requestAnimationFrame(updateGameClock);
+  }
+
+  async function finishRun() {
+    if (!running) return;
+    running = false;
+    cancelAnimationFrame(gameLoop);
+    timeEl.textContent = '0.0';
+    rivalVideo?.pause();
+    if (rivalScoreEl) rivalScoreEl.textContent = String(rivalFinalScore);
+    setStatus(tr('Time — finalising the recogniser…'), 'busy');
+
+    await stopRecognition();
+    syncOfficialScore();
+    const blob = await stopRecording();
+
+    setStatus(tr('Run complete — final recognitions locked'), 'ready');
+    resultScore.textContent = String(score);
+    resultCopy.textContent = rivalName
+      ? score > rivalFinalScore
+        ? `You beat ${rivalName} by ${score - rivalFinalScore}.`
+        : score === rivalFinalScore
+          ? `You tied ${rivalName}.`
+          : `${rivalName} is ahead by ${rivalFinalScore - score}.`
+      : `Counted ${score} clear six sevens.`;
+    shareText.value = shareableResult();
+    copyShareStatus.textContent = '';
+    resultCard.hidden = false;
+    recordingReview.hidden = false;
+
+    if (blob) {
+      if (recordingUrl) URL.revokeObjectURL(recordingUrl);
+      recordingUrl = URL.createObjectURL(blob);
+      recordingPreview.src = recordingUrl;
+      recordingDownload.href = recordingUrl;
+      const extension = blob.type === 'video/mp4' ? 'mp4' : 'webm';
+      recordingDownload.download = `six-seven-voice-counted.${extension}`;
+      recordingDownload.hidden = false;
+    }
+
+    resetButton.hidden = false;
+    resultCard.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+  }
+
+  function shareableResult() {
+    const blocks = score > 0
+      ? `${'🟩'.repeat(Math.min(score, 67))}${score > 67 ? ` +${score - 67}` : ''}`
+      : '⬜';
+    const gameUrl = new URL(app.dataset.gameUrl, window.location.origin);
+    const rival = rivalName ? ` · 🆚 ${rivalName} ${rivalFinalScore}` : '';
+    return `Six Seven Voice Speedrun — ${score} clear 67s${rival}\n${blocks}\n${gameUrl.href}`;
+  }
+
+  async function copyShareResult() {
+    if (!shareText.value) return;
+    try {
+      if (navigator.clipboard?.writeText && window.isSecureContext) {
+        await navigator.clipboard.writeText(shareText.value);
+      } else {
+        shareText.select();
+        shareText.setSelectionRange(0, shareText.value.length);
+        if (!document.execCommand('copy')) throw new Error('Copy command was rejected.');
+      }
+      copyShareButton.textContent = tr('Copied! 🎉');
+      copyShareStatus.textContent = tr('Result copied.');
+    } catch (error) {
+      copyShareStatus.textContent = tr('Automatic copy failed. Select the text and copy it manually.');
+    }
+    window.setTimeout(() => { copyShareButton.textContent = tr('Copy to clipboard'); }, 1500);
+  }
+
+  function discardRecording() {
+    if (recordingUrl) URL.revokeObjectURL(recordingUrl);
+    recordingUrl = null;
+    recordingBlob = null;
+    recordingPreview.removeAttribute('src');
+    recordingPreview.load();
+    recordingDownload.removeAttribute('href');
+    recordingDownload.hidden = true;
+    recordingReview.hidden = true;
+    if (uploadStatus) uploadStatus.textContent = tr('Recording discarded. Nothing was uploaded.');
+  }
+
+  function resetRun() {
+    discardRecording();
+    try { recognition?.abort(); } catch (error) { console.debug(error); }
+    recognition = null;
+    recognitionActive = false;
+    recognitionStopping = false;
+    finalisingRecognition = false;
+    score = 0;
+    eventTimeline = [];
+    completedTranscript = [];
+    sessionFinalTranscript = '';
+    sessionInterimTranscript = '';
+    runStartedAt = 0;
+    endTime = 0;
+    rivalTimelineIndex = 0;
+    scoreEl.textContent = '0';
+    timeEl.textContent = GAME_SECONDS.toFixed(1);
+    updateTranscriptUI();
+    if (rivalScoreEl) rivalScoreEl.textContent = '0';
+    if (rivalVideo) {
+      rivalVideo.pause();
+      if (rivalVideo.readyState) rivalVideo.currentTime = 0;
+    }
+    resultCard.hidden = true;
+    shareText.value = '';
+    copyShareStatus.textContent = '';
+    resetButton.hidden = true;
+    startButton.hidden = false;
+    startButton.disabled = !stream;
+    showError('');
+    setStatus(tr('Ready for another voice run'), 'ready');
+  }
+
+  function openPublicationModal() {
+    if (!publicationModal) return;
+    publicationModal.hidden = false;
+    publicationConsent.checked = false;
+    confirmPublication.disabled = true;
+  }
+
+  function closePublicationModal() {
+    if (publicationModal) publicationModal.hidden = true;
+  }
+
+  async function submitRecording() {
+    if (!recordingBlob || !submitButton) return;
+    if (!publicationConsent?.checked) {
+      openPublicationModal();
+      return;
+    }
+
+    const maxBytes = Number(app.dataset.maxUploadMb) * 1024 * 1024;
+    if (recordingBlob.size > maxBytes) {
+      uploadStatus.textContent = `Recording exceeded the ${app.dataset.maxUploadMb} MB upload limit.`;
+      return;
+    }
+
+    const turnstileResponse = document.querySelector('[name="cf-turnstile-response"]')?.value || '';
+    const extension = recordingBlob.type === 'video/mp4' ? 'mp4' : 'webm';
+    const form = new FormData();
+    form.append('game_mode', 'voice_67');
+    form.append('score', String(score));
+    form.append('event_timeline', JSON.stringify(eventTimeline));
+    form.append('publication_consent', 'yes');
+    form.append('video', recordingBlob, `six-seven-voice.${extension}`);
+    if (displayNameInput) form.append('display_name', displayNameInput.value);
+    if (turnstileResponse) form.append('cf-turnstile-response', turnstileResponse);
+
+    submitButton.disabled = true;
+    uploadStatus.textContent = tr('Uploading video…');
+    try {
+      const response = await fetch(app.dataset.submitUrl, {
+        method: 'POST',
+        body: form,
+        headers: { 'X-CSRFToken': csrfToken() },
+        credentials: 'same-origin',
+      });
+      const rawResponse = await response.text();
+      let payload;
+      try {
+        payload = JSON.parse(rawResponse);
+      } catch {
+        throw new Error(`The server returned HTTP ${response.status} instead of JSON.`);
+      }
+      if (!response.ok) throw new Error(payload.error || 'Upload failed.');
+      uploadStatus.textContent = payload.message;
+      submitButton.hidden = true;
+      if (discardButton) discardButton.hidden = true;
+      window.setTimeout(() => { window.location.href = payload.entry_url || app.dataset.hallUrl; }, 900);
+    } catch (error) {
+      uploadStatus.textContent = error.message;
+      submitButton.disabled = false;
+    }
+  }
+
+  installMp4Download(recordingDownload, {
+    filename: 'six-seven-voice-counted.webm',
+    onError(error) {
+      showError(`MP4 download failed: ${error.message}`);
+    },
+  });
+
+  if (!SpeechRecognitionCtor) {
+    enableButton.disabled = true;
+    setStatus(tr('Speech recognition is unavailable in this browser'));
+    showError(tr('This browser does not expose SpeechRecognition. Use a supported browser for Voice Speedrun.'));
+  } else {
+    setStatus(tr('Ready to request camera and microphone'), 'ready');
+  }
+
+  enableButton.addEventListener('click', enableVoice);
+  startButton.addEventListener('click', beginRun);
+  resetButton.addEventListener('click', resetRun);
+  copyShareButton.addEventListener('click', copyShareResult);
+  submitButton?.addEventListener('click', () => {
+    if (publicationConsent?.checked) submitRecording();
+    else openPublicationModal();
+  });
+  discardButton?.addEventListener('click', discardRecording);
+  publicationConsent?.addEventListener('change', () => {
+    confirmPublication.disabled = !publicationConsent.checked;
+  });
+  confirmPublication?.addEventListener('click', async () => {
+    if (!publicationConsent.checked) return;
+    closePublicationModal();
+    await submitRecording();
+  });
+  document.querySelectorAll('[data-close-publication-modal]').forEach((node) => {
+    node.addEventListener('click', closePublicationModal);
+  });
+}

--- a/brainrot/static/brainrot/voice_engine.js
+++ b/brainrot/static/brainrot/voice_engine.js
@@ -1,7 +1,9 @@
 export function normaliseVoiceTranscript(value) {
   return String(value ?? '')
     .toLowerCase()
-    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .replace(/\[unk\]/g, ' [unk] ')
+    .replace(/[^\p{L}\[\]]+/gu, ' ')
+    .replace(/\s+/g, ' ')
     .trim();
 }
 
@@ -11,21 +13,8 @@ export function countSixSevenPhrases(value) {
 
   const tokens = normalised.split(/\s+/);
   let count = 0;
-  for (let index = 0; index < tokens.length; index += 1) {
-    const token = tokens[index];
-
-    // Some recognisers normalise the spoken pair "six seven" to the number 67.
-    // Treat one standalone 67 token as one pair, but do not accept fuzzy words
-    // such as "sixty seven" or a fused "sixseven" token.
-    if (token === '67') {
-      count += 1;
-      continue;
-    }
-
-    const isSix = token === 'six' || token === '6';
-    const next = tokens[index + 1];
-    const isSeven = next === 'seven' || next === '7';
-    if (isSix && isSeven) {
+  for (let index = 0; index + 1 < tokens.length; index += 1) {
+    if (tokens[index] === 'six' && tokens[index + 1] === 'seven') {
       count += 1;
       index += 1;
     }

--- a/brainrot/static/brainrot/voice_engine.js
+++ b/brainrot/static/brainrot/voice_engine.js
@@ -1,0 +1,34 @@
+export function normaliseVoiceTranscript(value) {
+  return String(value ?? '')
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}]+/gu, ' ')
+    .trim();
+}
+
+export function countSixSevenPhrases(value) {
+  const normalised = normaliseVoiceTranscript(value);
+  if (!normalised) return 0;
+
+  const tokens = normalised.split(/\s+/);
+  let count = 0;
+  for (let index = 0; index < tokens.length; index += 1) {
+    const token = tokens[index];
+
+    // Some recognisers normalise the spoken pair "six seven" to the number 67.
+    // Treat one standalone 67 token as one pair, but do not accept fuzzy words
+    // such as "sixty seven" or a fused "sixseven" token.
+    if (token === '67') {
+      count += 1;
+      continue;
+    }
+
+    const isSix = token === 'six' || token === '6';
+    const next = tokens[index + 1];
+    const isSeven = next === 'seven' || next === '7';
+    if (isSix && isSeven) {
+      count += 1;
+      index += 1;
+    }
+  }
+  return count;
+}

--- a/brainrot/static/brainrot/voice_vosk.js
+++ b/brainrot/static/brainrot/voice_vosk.js
@@ -1,0 +1,142 @@
+const VOSK_SCRIPT_URL = 'https://cdn.jsdelivr.net/npm/vosk-browser@0.0.8/dist/vosk.js';
+const VOSK_MODEL_URL = 'https://fiddle-app.github.io/voice-models/vosk-model-small-en-us-0.15.tar.gz';
+const SIX_SEVEN_GRAMMAR = JSON.stringify(['six', 'seven', '[unk]']);
+
+let scriptPromise = null;
+let modelPromise = null;
+let loadedModel = null;
+
+function loadScript(url) {
+  if (window.Vosk?.createModel) return Promise.resolve();
+  if (scriptPromise) return scriptPromise;
+
+  scriptPromise = new Promise((resolve, reject) => {
+    const existing = document.querySelector(`script[data-voice-vosk="${url}"]`);
+    if (existing) {
+      existing.addEventListener('load', resolve, { once: true });
+      existing.addEventListener('error', () => reject(new Error('Could not load the local voice runtime.')), { once: true });
+      return;
+    }
+
+    const script = document.createElement('script');
+    script.src = url;
+    script.async = true;
+    script.crossOrigin = 'anonymous';
+    script.dataset.voiceVosk = url;
+    script.addEventListener('load', resolve, { once: true });
+    script.addEventListener('error', () => reject(new Error('Could not load the local voice runtime.')), { once: true });
+    document.head.appendChild(script);
+  }).then(() => {
+    if (!window.Vosk?.createModel) throw new Error('The local voice runtime loaded without the Vosk API.');
+  }).catch((error) => {
+    scriptPromise = null;
+    throw error;
+  });
+
+  return scriptPromise;
+}
+
+export async function loadSixSevenVoiceModel(onStatus = () => {}) {
+  if (loadedModel?.ready) return loadedModel;
+  if (!modelPromise) {
+    modelPromise = (async () => {
+      onStatus('Loading local voice runtime…');
+      await loadScript(VOSK_SCRIPT_URL);
+      onStatus('Loading local English voice model (~40 MB on first visit)…');
+      const model = await window.Vosk.createModel(VOSK_MODEL_URL);
+      if (!model?.ready) throw new Error('The local voice model did not become ready.');
+      loadedModel = model;
+      onStatus('Local voice model ready');
+      return model;
+    })().catch((error) => {
+      modelPromise = null;
+      throw error;
+    });
+  }
+  return modelPromise;
+}
+
+export class SixSevenLocalRecognizer {
+  constructor(model, sampleRate, handlers = {}) {
+    this.handlers = handlers;
+    this.lastPartial = '';
+    this.finalising = null;
+    this.recognizer = new model.KaldiRecognizer(sampleRate, SIX_SEVEN_GRAMMAR);
+    this.recognizer.setWords(true);
+
+    this.recognizer.on('partialresult', (message) => {
+      this.lastPartial = message?.result?.partial?.trim() || '';
+      this.handlers.onPartial?.(this.lastPartial);
+    });
+
+    this.recognizer.on('result', (message) => {
+      const text = message?.result?.text?.trim() || '';
+      this.lastPartial = '';
+      this.handlers.onResult?.(text, message?.result?.result || []);
+      if (this.finalising) {
+        const resolve = this.finalising;
+        this.finalising = null;
+        resolve(text);
+      }
+    });
+
+    this.recognizer.on('error', (message) => {
+      const error = new Error(message?.error || 'Local voice recognition failed.');
+      this.handlers.onError?.(error);
+      if (this.finalising) {
+        const resolve = this.finalising;
+        this.finalising = null;
+        resolve('');
+      }
+    });
+  }
+
+  acceptWaveform(audioBuffer) {
+    this.recognizer.acceptWaveform(audioBuffer);
+  }
+
+  finalise(timeoutMs = 1500) {
+    if (this.finalising) return Promise.resolve('');
+
+    return new Promise((resolve) => {
+      let settled = false;
+      const finish = (text = '') => {
+        if (settled) return;
+        settled = true;
+        window.clearTimeout(timer);
+        if (this.finalising === finish) this.finalising = null;
+        resolve(text);
+      };
+      this.finalising = finish;
+
+      const timer = window.setTimeout(() => finish(''), timeoutMs);
+      try {
+        this.recognizer.retrieveFinalResult();
+      } catch (error) {
+        this.handlers.onError?.(error);
+        finish('');
+      }
+    });
+  }
+
+  remove() {
+    try {
+      this.recognizer?.remove();
+    } finally {
+      this.recognizer = null;
+      this.finalising = null;
+    }
+  }
+}
+
+export function releaseSixSevenVoiceModel() {
+  if (loadedModel) {
+    try {
+      loadedModel.terminate();
+    } catch (error) {
+      console.debug('Vosk model cleanup failed.', error);
+    }
+  }
+  loadedModel = null;
+  modelPromise = null;
+}

--- a/brainrot/templates/brainrot/hall_of_fame.html
+++ b/brainrot/templates/brainrot/hall_of_fame.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load static i18n %}
 
-{% block title %}{% if game_mode == 'leg_claps' %}{% translate "Tung Tung Leg Claps Hall of Fame" %}{% else %}{% translate "67 Hall of Fame" %}{% endif %}{% endblock %}
+{% block title %}{% if game_mode == 'leg_claps' %}{% translate "Tung Tung Leg Claps Hall of Fame" %}{% elif game_mode == 'voice_67' %}{% translate "Six Seven Voice Speedrun Hall of Fame" %}{% else %}{% translate "67 Hall of Fame" %}{% endif %}{% endblock %}
 
 {% block content %}
 <main class="container py-4 py-md-5">
@@ -15,13 +15,26 @@
   <div class="row g-4 align-items-end mb-4">
     <div class="col-12 col-lg-8">
       <div class="text-secondary small text-uppercase fw-semibold mb-2">{% translate "PUBLIC 20-SECOND VIDEO LEADERBOARD" %}</div>
-      <h1 class="display-5 fw-bold mb-2">{% if game_mode == 'leg_claps' %}{% translate "Leg Claps Hall of Fame" %}{% else %}{% translate "67 Hall of Fame" %}{% endif %}</h1>
-      <p class="lead text-secondary mb-0">{% if game_mode == 'leg_claps' %}{% translate "See who made the most inward knee claps in 20 seconds, watch each run, then challenge it yourself. Each clap requires the knees to open again before the next count." %}{% else %}{% translate "See who made the most 6️⃣7️⃣ moves in 20 seconds, watch each run, then challenge it yourself. Guest names are visibly labelled and cannot copy registered usernames." %}{% endif %}</p>
+      <h1 class="display-5 fw-bold mb-2">
+        {% if game_mode == 'leg_claps' %}{% translate "Leg Claps Hall of Fame" %}
+        {% elif game_mode == 'voice_67' %}{% translate "Voice 67 Hall of Fame" %}
+        {% else %}{% translate "67 Hall of Fame" %}{% endif %}
+      </h1>
+      <p class="lead text-secondary mb-0">
+        {% if game_mode == 'leg_claps' %}
+          {% translate "See who made the most inward knee claps in 20 seconds, watch each run, then challenge it yourself. Each clap requires the knees to open again before the next count." %}
+        {% elif game_mode == 'voice_67' %}
+          {% translate "See who clearly said “six seven” the most times in 20 seconds. The recogniser only awards complete recognised pairs; the evidence video includes microphone audio." %}
+        {% else %}
+          {% translate "See who made the most 6️⃣7️⃣ moves in 20 seconds, watch each run, then challenge it yourself. Guest names are visibly labelled and cannot copy registered usernames." %}
+        {% endif %}
+      </p>
     </div>
     <div class="col-12 col-lg-4 text-lg-end">
-      <div class="btn-group" role="group" aria-label="{% translate 'Leaderboard mode' %}">
+      <div class="btn-group flex-wrap" role="group" aria-label="{% translate 'Leaderboard mode' %}">
         <a class="btn {% if game_mode == 'six_seven' %}btn-primary{% else %}btn-outline-primary{% endif %}" href="{% url 'brainrot:hall_of_fame' %}?mode=six_seven">67 Counter</a>
         <a class="btn {% if game_mode == 'leg_claps' %}btn-success{% else %}btn-outline-success{% endif %}" href="{% url 'brainrot:hall_of_fame' %}?mode=leg_claps">{% translate "Tung Tung Leg Claps" %}</a>
+        <a class="btn {% if game_mode == 'voice_67' %}btn-danger{% else %}btn-outline-danger{% endif %}" href="{% url 'brainrot:hall_of_fame' %}?mode=voice_67">{% translate "Voice 67" %}</a>
       </div>
     </div>
   </div>
@@ -37,18 +50,28 @@
           <div class="col">
             <h2 class="h5 border-0 ps-0 ms-0 mb-1">{{ entry.public_name }}</h2>
             <div class="text-secondary small">
-              {% if entry.game_mode == 'leg_claps' %}{% blocktranslate with score=entry.score date=entry.created_at|date:'j M Y' %}made {{ score }} leg claps in 20 seconds · {{ date }}{% endblocktranslate %}{% else %}{% blocktranslate with score=entry.score date=entry.created_at|date:'j M Y' %}made {{ score }} 6️⃣7️⃣ moves in 20 seconds · {{ date }}{% endblocktranslate %}{% endif %}
+              {% if entry.game_mode == 'leg_claps' %}
+                {% blocktranslate with score=entry.score date=entry.created_at|date:'j M Y' %}made {{ score }} leg claps in 20 seconds · {{ date }}{% endblocktranslate %}
+              {% elif entry.game_mode == 'voice_67' %}
+                {% blocktranslate with score=entry.score date=entry.created_at|date:'j M Y' %}said “six seven” {{ score }} times in 20 seconds · {{ date }}{% endblocktranslate %}
+              {% else %}
+                {% blocktranslate with score=entry.score date=entry.created_at|date:'j M Y' %}made {{ score }} 6️⃣7️⃣ moves in 20 seconds · {{ date }}{% endblocktranslate %}
+              {% endif %}
             </div>
           </div>
           <div class="col-auto text-end">
             <div class="display-6 fw-bold">{{ entry.score }}</div>
-            <small class="text-secondary">{% if entry.game_mode == 'leg_claps' %}{% translate "claps" %}{% else %}{% translate "moves" %}{% endif %}</small>
+            <small class="text-secondary">{% if entry.game_mode == 'leg_claps' %}{% translate "claps" %}{% elif entry.game_mode == 'voice_67' %}{% translate "67s" %}{% else %}{% translate "moves" %}{% endif %}</small>
           </div>
         </div>
 
         <div class="d-flex flex-wrap gap-2 mt-3">
           <a class="btn btn-sm btn-outline-dark" href="{% url 'brainrot:hall_of_fame_detail' entry.id %}">{% translate "Full details" %}</a>
-          <a class="btn btn-sm btn-primary" href="{% url 'brainrot:challenge' entry.id %}">{% translate "Challenge this run" %}</a>
+          {% if entry.game_mode == 'voice_67' %}
+            <a class="btn btn-sm btn-danger" href="{% url 'brainrot:voice_counter' %}?rival={{ entry.id }}">{% translate "Challenge this run" %}</a>
+          {% else %}
+            <a class="btn btn-sm btn-primary" href="{% url 'brainrot:challenge' entry.id %}">{% translate "Challenge this run" %}</a>
+          {% endif %}
         </div>
 
         {% url 'brainrot:hall_of_fame_video' entry.id as preview_url %}
@@ -59,7 +82,15 @@
               <video class="w-100 rounded bg-dark" controls preload="none" playsinline src="{{ preview_url }}"></video>
             </div>
             <div class="col-12 col-lg-6">
-              <strong>{% if entry.game_mode == 'leg_claps' %}{% blocktranslate with name=entry.public_name score=entry.score %}{{ name }} made {{ score }} Tung Tung Leg Claps in 20 seconds.{% endblocktranslate %}{% else %}{% blocktranslate with name=entry.public_name score=entry.score %}{{ name }} made {{ score }} 6️⃣7️⃣ moves in 20 seconds.{% endblocktranslate %}{% endif %}</strong>
+              <strong>
+                {% if entry.game_mode == 'leg_claps' %}
+                  {% blocktranslate with name=entry.public_name score=entry.score %}{{ name }} made {{ score }} Tung Tung Leg Claps in 20 seconds.{% endblocktranslate %}
+                {% elif entry.game_mode == 'voice_67' %}
+                  {% blocktranslate with name=entry.public_name score=entry.score %}{{ name }} clearly said “six seven” {{ score }} times in 20 seconds.{% endblocktranslate %}
+                {% else %}
+                  {% blocktranslate with name=entry.public_name score=entry.score %}{{ name }} made {{ score }} 6️⃣7️⃣ moves in 20 seconds.{% endblocktranslate %}
+                {% endif %}
+              </strong>
               <p class="text-secondary small mt-2">{% translate "Open the detail page to share this run, download it, or start a synchronized challenge." %}</p>
               <div class="d-flex flex-wrap gap-2">
                 <a href="{% url 'brainrot:hall_of_fame_detail' entry.id %}">{% translate "Open full run" %} →</a>
@@ -76,7 +107,11 @@
       <div class="card-body p-4 text-center">
         <h2 class="h4 border-0 ps-0 ms-0">{% translate "No legends yet." %}</h2>
         <p class="text-secondary">{% translate "The scientific community has uploaded absolutely nothing." %}</p>
-        <a href="{% url 'brainrot:counter' %}?mode={{ game_mode }}" class="btn btn-primary">{% translate "Submit the first specimen" %}</a>
+        {% if game_mode == 'voice_67' %}
+          <a href="{% url 'brainrot:voice_counter' %}" class="btn btn-danger">{% translate "Submit the first specimen" %}</a>
+        {% else %}
+          <a href="{% url 'brainrot:counter' %}?mode={{ game_mode }}" class="btn btn-primary">{% translate "Submit the first specimen" %}</a>
+        {% endif %}
       </div>
     </div>
     {% endfor %}

--- a/brainrot/templates/brainrot/hall_of_fame_detail.html
+++ b/brainrot/templates/brainrot/hall_of_fame_detail.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% load static i18n %}
 
-{% block title %}{{ entry.public_name }} — {% if entry.game_mode == 'leg_claps' %}{% translate "Tung Tung Leg Claps Hall of Fame" %}{% else %}{% translate "67 Hall of Fame" %}{% endif %}{% endblock %}
+{% block title %}{{ entry.public_name }} — {% if entry.game_mode == 'leg_claps' %}{% translate "Tung Tung Leg Claps Hall of Fame" %}{% elif entry.game_mode == 'voice_67' %}{% translate "Six Seven Voice Speedrun Hall of Fame" %}{% else %}{% translate "67 Hall of Fame" %}{% endif %}{% endblock %}
 
 {% block content %}
 <main class="container py-4 py-md-5" id="hof-detail"
@@ -20,12 +20,20 @@
       <div class="d-flex flex-wrap align-items-end gap-3">
         <h1 class="display-2 fw-bold mb-0">{{ entry.score }}</h1>
         <div class="pb-2">
-          <div class="fw-bold">{% if entry.game_mode == 'leg_claps' %}{% blocktranslate with name=entry.public_name score=entry.score %}{{ name }} made {{ score }} Tung Tung Leg Claps in 20 seconds.{% endblocktranslate %}{% else %}{% blocktranslate with name=entry.public_name score=entry.score %}{{ name }} made {{ score }} 6️⃣7️⃣ moves in 20 seconds.{% endblocktranslate %}{% endif %}</div>
+          <div class="fw-bold">
+            {% if entry.game_mode == 'leg_claps' %}
+              {% blocktranslate with name=entry.public_name score=entry.score %}{{ name }} made {{ score }} Tung Tung Leg Claps in 20 seconds.{% endblocktranslate %}
+            {% elif entry.game_mode == 'voice_67' %}
+              {% blocktranslate with name=entry.public_name score=entry.score %}{{ name }} clearly said “six seven” {{ score }} times in 20 seconds.{% endblocktranslate %}
+            {% else %}
+              {% blocktranslate with name=entry.public_name score=entry.score %}{{ name }} made {{ score }} 6️⃣7️⃣ moves in 20 seconds.{% endblocktranslate %}
+            {% endif %}
+          </div>
           <div class="text-secondary small">{{ entry.created_at|date:'j M Y · H:i' }} · {% blocktranslate with duration=entry.duration_seconds|floatformat:2 %}{{ duration }} seconds{% endblocktranslate %}</div>
         </div>
       </div>
       <div class="d-flex flex-wrap gap-2 mt-2">
-        <span class="badge {% if entry.game_mode == 'leg_claps' %}text-bg-success{% else %}text-bg-primary{% endif %}">{{ entry.get_game_mode_display }}</span>
+        <span class="badge {% if entry.game_mode == 'leg_claps' %}text-bg-success{% elif entry.game_mode == 'voice_67' %}text-bg-danger{% else %}text-bg-primary{% endif %}">{{ entry.get_game_mode_display }}</span>
         <span class="badge {% if entry.visibility == 'public' %}text-bg-success{% else %}text-bg-secondary{% endif %}">{{ entry.get_visibility_display }}</span>
       </div>
     </div>
@@ -40,7 +48,11 @@
           <div class="d-flex flex-wrap gap-2 mt-3">
             <a class="btn btn-outline-secondary" href="{{ evidence_url }}?download=1">{% translate "Download counted video" %}</a>
             {% if entry.visibility == 'public' %}
-            <a class="btn btn-primary" href="{% url 'brainrot:challenge' entry.id %}">{% translate "Challenge this specimen" %}</a>
+              {% if entry.game_mode == 'voice_67' %}
+                <a class="btn btn-danger" href="{% url 'brainrot:voice_counter' %}?rival={{ entry.id }}">{% translate "Challenge this specimen" %}</a>
+              {% else %}
+                <a class="btn btn-primary" href="{% url 'brainrot:challenge' entry.id %}">{% translate "Challenge this specimen" %}</a>
+              {% endif %}
             {% endif %}
           </div>
         </div>

--- a/brainrot/templates/brainrot/index.html
+++ b/brainrot/templates/brainrot/index.html
@@ -17,7 +17,7 @@
   </div>
 
   <div class="row g-3 g-lg-4">
-    <div class="col-12 col-md-6 col-xl-4">
+    <div class="col-12 col-md-6 col-xl-3">
       <a class="card h-100 text-decoration-none text-body shadow-sm border-primary" href="{% url 'brainrot:counter' %}?mode=six_seven">
         <div class="card-body p-4 d-flex flex-column">
           <div class="d-flex align-items-start justify-content-between gap-3 mb-4">
@@ -31,7 +31,7 @@
       </a>
     </div>
 
-    <div class="col-12 col-md-6 col-xl-4">
+    <div class="col-12 col-md-6 col-xl-3">
       <a class="card h-100 text-decoration-none text-body shadow-sm border-success" href="{% url 'brainrot:counter' %}?mode=leg_claps">
         <div class="card-body p-4 d-flex flex-column">
           <div class="d-flex align-items-start justify-content-between gap-3 mb-4">
@@ -45,7 +45,21 @@
       </a>
     </div>
 
-    <div class="col-12 col-md-6 col-xl-4">
+    <div class="col-12 col-md-6 col-xl-3">
+      <a class="card h-100 text-decoration-none text-body shadow-sm border-danger" href="{% url 'brainrot:voice_counter' %}">
+        <div class="card-body p-4 d-flex flex-column">
+          <div class="d-flex align-items-start justify-content-between gap-3 mb-4">
+            <span class="badge text-bg-danger">20 s · voice</span>
+            <span class="display-6 fw-bold text-danger">🗣️</span>
+          </div>
+          <h2 class="h3 fw-bold">{% translate "Six Seven Voice Speedrun" %}</h2>
+          <p class="text-secondary flex-grow-1 mb-4">{% translate "Say “six seven” as many times as possible. Only complete recognised pairs count, so speed without clear speech gets punished." %}</p>
+          <span class="fw-semibold text-danger">{% translate "Speak" %} →</span>
+        </div>
+      </a>
+    </div>
+
+    <div class="col-12 col-md-6 col-xl-3">
       <a class="card h-100 text-decoration-none text-body shadow-sm border-secondary" href="{% url 'brainrot:typing_test' %}">
         <div class="card-body p-4 d-flex flex-column">
           <div class="d-flex align-items-start justify-content-between gap-3 mb-4">

--- a/brainrot/templates/brainrot/voice_counter.html
+++ b/brainrot/templates/brainrot/voice_counter.html
@@ -1,0 +1,205 @@
+{% extends 'base.html' %}
+{% load static i18n %}
+
+{% block title %}{% translate "Six Seven Voice Speedrun" %}{% endblock %}
+
+{% block content %}
+<link rel="stylesheet" href="{% static 'brainrot/counter_bootstrap.css' %}">
+{% if turnstile_enabled %}<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>{% endif %}
+
+<main class="container py-4 py-md-5 counter-page" id="voice-app"
+      data-submit-url="{% url 'brainrot:submit_hall_of_fame' %}"
+      data-hall-url="{% url 'brainrot:hall_of_fame' %}?mode=voice_67"
+      data-game-url="{% url 'brainrot:voice_counter' %}"
+      data-max-upload-mb="{{ max_upload_mb }}"
+      data-game-mode="voice_67"
+      {% if rival %}data-rival-name="{{ rival.public_name }}" data-rival-score="{{ rival.score }}"{% endif %}>
+
+  <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-4">
+    <a class="btn btn-sm btn-outline-secondary" href="{% url 'brainrot:index' %}">← 67 Games</a>
+    <a class="btn btn-sm btn-outline-dark" href="{% url 'brainrot:hall_of_fame' %}?mode=voice_67">
+      <i class="fa-solid fa-ranking-star me-1"></i> {% translate "Hall of Fame" %}
+    </a>
+  </div>
+
+  <header class="counter-heading mb-4">
+    {% if rival %}
+      <span class="badge text-bg-dark mode-badge mb-2">{% translate "Challenge mode:" %} {% translate "Six Seven Voice Speedrun" %}</span>
+      <h1 class="display-5 mb-2">YOU vs {{ rival.public_name }}</h1>
+      <p class="lead text-secondary mb-0">{% blocktranslate with name=rival.public_name score=rival.score %}{{ name }} clearly said “six seven” {{ score }} times in 20 seconds. Their evidence video plays muted so it cannot contaminate your microphone.{% endblocktranslate %}</p>
+    {% else %}
+      <span class="badge text-bg-danger mode-badge mb-2">20 seconds · camera + microphone</span>
+      <h1 class="display-5 mb-2">{% translate "Six Seven Voice Speedrun" %}</h1>
+      <p class="lead text-secondary mb-0">{% translate "Say “six seven” as many times as possible in 20 seconds. Only complete recognised pairs count — mumbling that the recogniser cannot resolve does not." %}</p>
+    {% endif %}
+  </header>
+
+  <div class="alert alert-info py-2 px-3 small" role="note">
+    <strong>{% translate "Voice privacy:" %}</strong>
+    {% translate "The evidence recording stays in this browser unless you submit it. Speech recognition is supplied by your browser and may use the browser vendor's speech service; availability and processing therefore depend on the browser. Submitting publishes the camera-and-microphone recording for anyone to watch." %}
+  </div>
+
+  <div class="row g-4 align-items-start">
+    <div class="{% if rival %}col-12 col-xl-9{% else %}col-12 col-lg-8{% endif %}">
+      <div class="row g-3">
+        {% if rival %}
+        <div class="col-12 col-md-6">
+          <section class="camera-card h-100">
+            <div class="camera-stage rival-stage">
+              <video id="rival-video" muted playsinline preload="auto" src="{% url 'brainrot:hall_of_fame_video' rival.id %}"></video>
+              <div class="rival-score-pill">
+                <span>{{ rival.public_name }}</span>
+                <strong id="rival-score">0</strong>
+              </div>
+            </div>
+            <div class="detector-status ready">
+              <span class="status-dot"></span>
+              <span>{% if rival_timeline_exact %}{% translate "Recorded recognition timeline ready" %}{% else %}{% translate "Estimated recognition pace" %}{% endif %}</span>
+            </div>
+          </section>
+        </div>
+        {{ rival_timeline|json_script:"rival-event-timeline" }}
+        {% endif %}
+
+        <div class="{% if rival %}col-12 col-md-6{% else %}col-12{% endif %}">
+          <section class="camera-card">
+            <div class="camera-stage" id="camera-stage">
+              <video id="camera" playsinline muted></video>
+              <canvas id="recording-overlay" hidden></canvas>
+              <div class="camera-placeholder" id="camera-placeholder">
+                <span class="counter-placeholder-mark">🗣️</span>
+                <span>{% translate "Camera and microphone off" %}</span>
+              </div>
+              <div class="countdown" id="countdown" aria-live="assertive"></div>
+              <div class="live-pill" id="live-pill" hidden>● {% translate "RECORDING LOCALLY" %}</div>
+            </div>
+            <div class="detector-status" id="voice-status">
+              <span class="status-dot"></span>
+              <span>{% translate "Waiting for camera and microphone permission" %}</span>
+            </div>
+          </section>
+
+          <section class="card shadow-sm mt-3">
+            <div class="card-body p-3">
+              <div class="text-secondary small text-uppercase fw-semibold mb-1">{% translate "Recognizer transcript" %}</div>
+              <div id="heard-final" class="fw-semibold" aria-live="polite">—</div>
+              <div id="heard-interim" class="text-secondary small mt-1"></div>
+              <p class="small text-secondary mb-0 mt-2">{% translate "Final recognitions are the official score. Interim text is only a live preview and may change." %}</p>
+            </div>
+          </section>
+        </div>
+      </div>
+    </div>
+
+    <aside class="{% if rival %}col-12 col-xl-3{% else %}col-12 col-lg-4{% endif %}">
+      <section class="score-card p-3 p-md-4 mb-3">
+        <div class="text-secondary small text-uppercase fw-semibold">{% translate "six sevens counted" %}</div>
+        <div class="score-value my-2" id="score">0</div>
+        <div class="d-flex justify-content-between align-items-end border-top pt-3 mb-3">
+          <span class="text-secondary small text-uppercase fw-semibold">{% translate "time remaining" %}</span>
+          <strong class="timer-value" id="counter-time">20.0</strong>
+        </div>
+
+        {% if rival %}
+        <div class="alert alert-light border py-2 px-3 small">
+          <span class="text-secondary">{% translate "score to beat" %}</span>
+          <strong class="float-end">{{ rival.score }}</strong><br>
+          <a href="{% url 'brainrot:hall_of_fame_detail' rival.id %}">{% translate "View HOF entry" %}</a>
+        </div>
+        {% endif %}
+
+        <div class="d-grid gap-2">
+          <button class="btn btn-danger" id="enable-voice">{% translate "Enable camera + microphone" %}</button>
+          <button class="btn btn-danger" id="start-run" disabled hidden>{% translate "I'm ready" %}</button>
+          <button class="btn btn-outline-secondary" id="reset-run" hidden>{% translate "Try again" %}</button>
+        </div>
+        <p class="small text-secondary mt-3 mb-0">{% translate "Speak fast, but clearly enough that the same recogniser can actually hear each complete six-seven pair." %}</p>
+        <p class="counter-error text-danger small mt-2 mb-0" id="voice-error" role="alert"></p>
+      </section>
+
+      <a class="hof-card d-flex align-items-center gap-3 p-3 text-decoration-none text-body" href="{% url 'brainrot:hall_of_fame' %}?mode=voice_67">
+        <span class="hof-mark">67</span>
+        <span>
+          <small class="text-secondary d-block">VOICE LEADERBOARD</small>
+          <strong>{% translate "Hall of Fame" %} →</strong>
+        </span>
+      </a>
+    </aside>
+  </div>
+
+  <section class="result-card p-3 p-md-4 mt-4" id="voice-result" hidden>
+    <div class="mb-4">
+      <div class="text-secondary small text-uppercase fw-semibold">RESULT</div>
+      <h2 class="h3 mt-1 mb-2"><span id="result-score">0</span> {% translate "clear six sevens in 20 seconds" %}</h2>
+      <p class="mb-0" id="result-copy">{% translate "Run complete." %}</p>
+    </div>
+
+    <div class="recording-review mb-4" id="recording-review" hidden>
+      <video id="recording-preview" controls playsinline></video>
+      <p class="small text-secondary mt-2">{% translate "This evidence video includes your microphone audio and the live count. It remains local unless you submit it below." %}</p>
+      <div class="d-flex flex-wrap gap-2 mb-3">
+        <a class="btn btn-outline-secondary" id="download-recording" hidden>{% translate "Download counted video" %}</a>
+      </div>
+
+      {% if not request.user.is_authenticated and anonymous_submission_available %}
+        <label class="anonymous-name-field form-label" for="hof-display-name">
+          <span>{% translate "Anonymous display name" %}</span>
+          <input class="form-control mt-1" id="hof-display-name" maxlength="32" placeholder="Anonymous Swan">
+        </label>
+        <p class="small text-secondary">{% translate "Guest runs are labelled “guest” and cannot impersonate registered usernames. Guest submissions have no self-service privacy or delete controls; contact me with the public HOF link for changes." %}</p>
+      {% elif request.user.is_authenticated %}
+        <p class="small text-secondary">{% blocktranslate with username=request.user.username %}Submitting as <strong>{{ username }}</strong>. New submissions are public, but you can later make the run private or delete it from My HOF.{% endblocktranslate %}</p>
+      {% else %}
+        <p class="small text-secondary">{% translate "Anonymous submission is temporarily unavailable because the production human-verification gate is not configured." %}</p>
+      {% endif %}
+
+      {% if request.user.is_authenticated or anonymous_submission_available %}
+        {% if turnstile_enabled %}<div class="cf-turnstile mb-3" data-sitekey="{{ turnstile_site_key }}"></div>{% endif %}
+        <div class="d-flex flex-wrap gap-2">
+          <button class="btn btn-primary" id="submit-hof" type="button">{% translate "Submit to Hall of Fame" %}</button>
+          <button class="btn btn-outline-danger" id="discard-recording" type="button">{% translate "Discard recording" %}</button>
+        </div>
+      {% else %}
+        <div class="d-flex flex-wrap gap-2">
+          <a class="btn btn-primary" href="{% url 'login' %}?next={{ request.path|urlencode }}">{% translate "Log in to submit this run" %}</a>
+          <button class="btn btn-outline-danger" id="discard-recording" type="button">{% translate "Discard recording" %}</button>
+        </div>
+      {% endif %}
+      <p class="small mt-2 mb-0" id="upload-status" role="status"></p>
+    </div>
+
+    <div class="counter-share border-top pt-4">
+      <h3 class="h5">🎉 {% translate "Share your result!" %}</h3>
+      <textarea class="form-control mb-2" id="voice-share-text" rows="5" readonly aria-label="Shareable voice result"></textarea>
+      <button class="btn btn-outline-primary" id="copy-voice-share" type="button">{% translate "Copy to clipboard" %}</button>
+      <p class="small text-secondary mt-2 mb-0" id="copy-voice-status" role="status" aria-live="polite"></p>
+    </div>
+  </section>
+</main>
+
+<div class="publication-modal" id="publication-modal" hidden role="dialog" aria-modal="true" aria-labelledby="publication-modal-title">
+  <div class="publication-modal-backdrop" data-close-publication-modal></div>
+  <section class="publication-modal-card">
+    <button class="publication-modal-close" type="button" data-close-publication-modal aria-label="{% translate 'Close' %}">×</button>
+    <div class="text-secondary small text-uppercase fw-semibold mb-2">{% translate "PUBLICATION CONSENT" %}</div>
+    <h2 class="h4" id="publication-modal-title">{% translate "Your video and voice will be public" %}</h2>
+    <p>{% translate "Submitting publishes this camera-and-microphone recording to the Hall of Fame. Anyone can watch, hear, download and share it." %}</p>
+    {% if request.user.is_authenticated %}
+      <p class="small text-secondary">{% translate "Because you are logged in, you can make it private or delete it later from My HOF." %}</p>
+    {% else %}
+      <p class="small text-secondary">{% translate "Guest submissions cannot be privately managed or deleted by you later. Contact the site owner with the HOF link if you need it removed." %}</p>
+    {% endif %}
+    <label class="publication-consent-check">
+      <input class="form-check-input" type="checkbox" id="publication-consent">
+      <span>{% translate "I understand that my video and microphone audio will be published publicly." %}</span>
+    </label>
+    <div class="d-flex justify-content-end gap-2 mt-3">
+      <button class="btn btn-outline-secondary" type="button" data-close-publication-modal>{% translate "Cancel" %}</button>
+      <button class="btn btn-primary" type="button" id="confirm-publication">{% translate "Publish this run" %}</button>
+    </div>
+  </section>
+</div>
+
+<script src="{% url 'brainrot:javascript_catalog' %}"></script>
+<script type="module" src="{% static 'brainrot/voice_counter.js' %}"></script>
+{% endblock %}

--- a/brainrot/templates/brainrot/voice_counter.html
+++ b/brainrot/templates/brainrot/voice_counter.html
@@ -4,6 +4,8 @@
 {% block title %}{% translate "Six Seven Voice Speedrun" %}{% endblock %}
 
 {% block content %}
+<link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
+<link rel="preconnect" href="https://fiddle-app.github.io" crossorigin>
 <link rel="stylesheet" href="{% static 'brainrot/counter_bootstrap.css' %}">
 {% if turnstile_enabled %}<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>{% endif %}
 
@@ -28,15 +30,15 @@
       <h1 class="display-5 mb-2">YOU vs {{ rival.public_name }}</h1>
       <p class="lead text-secondary mb-0">{% blocktranslate with name=rival.public_name score=rival.score %}{{ name }} clearly said “six seven” {{ score }} times in 20 seconds. Their evidence video plays muted so it cannot contaminate your microphone.{% endblocktranslate %}</p>
     {% else %}
-      <span class="badge text-bg-danger mode-badge mb-2">20 seconds · camera + microphone</span>
+      <span class="badge text-bg-danger mode-badge mb-2">20 seconds · local voice model</span>
       <h1 class="display-5 mb-2">{% translate "Six Seven Voice Speedrun" %}</h1>
-      <p class="lead text-secondary mb-0">{% translate "Say “six seven” as many times as possible in 20 seconds. Only complete recognised pairs count — mumbling that the recogniser cannot resolve does not." %}</p>
+      <p class="lead text-secondary mb-0">{% translate "Say “six seven” as many times as possible in 20 seconds. Only complete pairs that the local model clearly resolves as six then seven count." %}</p>
     {% endif %}
   </header>
 
   <div class="alert alert-info py-2 px-3 small" role="note">
     <strong>{% translate "Voice privacy:" %}</strong>
-    {% translate "The evidence recording stays in this browser unless you submit it. Speech recognition is supplied by your browser and may use the browser vendor's speech service; availability and processing therefore depend on the browser. Submitting publishes the camera-and-microphone recording for anyone to watch." %}
+    {% translate "Recognition runs locally in this browser using a downloaded voice model; microphone audio is not sent to a speech-recognition service. The first visit downloads about 40 MB of model data. The evidence recording also stays local unless you submit it. Submitting publishes the camera-and-microphone recording for anyone to watch." %}
   </div>
 
   <div class="row g-4 align-items-start">
@@ -65,7 +67,6 @@
           <section class="camera-card">
             <div class="camera-stage" id="camera-stage">
               <video id="camera" playsinline muted></video>
-              <canvas id="recording-overlay" hidden></canvas>
               <div class="camera-placeholder" id="camera-placeholder">
                 <span class="counter-placeholder-mark">🗣️</span>
                 <span>{% translate "Camera and microphone off" %}</span>
@@ -75,16 +76,16 @@
             </div>
             <div class="detector-status" id="voice-status">
               <span class="status-dot"></span>
-              <span>{% translate "Waiting for camera and microphone permission" %}</span>
+              <span>{% translate "Preloading local voice model — camera and microphone remain off" %}</span>
             </div>
           </section>
 
           <section class="card shadow-sm mt-3">
             <div class="card-body p-3">
-              <div class="text-secondary small text-uppercase fw-semibold mb-1">{% translate "Recognizer transcript" %}</div>
+              <div class="text-secondary small text-uppercase fw-semibold mb-1">{% translate "Local model hearing" %}</div>
               <div id="heard-final" class="fw-semibold" aria-live="polite">—</div>
               <div id="heard-interim" class="text-secondary small mt-1"></div>
-              <p class="small text-secondary mb-0 mt-2">{% translate "Final recognitions are the official score. Interim text is only a live preview and may change." %}</p>
+              <p class="small text-secondary mb-0 mt-2">{% translate "The live line can revise itself while you speak. At 20 seconds the same local model is forced to finalise all audio received before the deadline." %}</p>
             </div>
           </section>
         </div>
@@ -110,10 +111,10 @@
 
         <div class="d-grid gap-2">
           <button class="btn btn-danger" id="enable-voice">{% translate "Enable camera + microphone" %}</button>
-          <button class="btn btn-danger" id="start-run" disabled hidden>{% translate "I'm ready" %}</button>
+          <button class="btn btn-danger" id="start-run" disabled hidden>{% translate "Loading local voice model…" %}</button>
           <button class="btn btn-outline-secondary" id="reset-run" hidden>{% translate "Try again" %}</button>
         </div>
-        <p class="small text-secondary mt-3 mb-0">{% translate "Speak fast, but clearly enough that the same recogniser can actually hear each complete six-seven pair." %}</p>
+        <p class="small text-secondary mt-3 mb-0">{% translate "The grammar is deliberately tiny: six, seven, and unknown. Speak fast, but if the model hears an unknown or the order is wrong, it does not count." %}</p>
         <p class="counter-error text-danger small mt-2 mb-0" id="voice-error" role="alert"></p>
       </section>
 

--- a/brainrot/test_voice.py
+++ b/brainrot/test_voice.py
@@ -16,8 +16,10 @@ class VoiceSpeedrunPageTests(TestCase):
         self.assertContains(voice, 'id="voice-app"')
         self.assertContains(voice, 'data-game-mode="voice_67"')
         self.assertContains(voice, 'voice_counter.js')
-        self.assertContains(voice, 'Recognizer transcript')
+        self.assertContains(voice, 'Local model hearing')
         self.assertContains(voice, 'camera + microphone')
+        self.assertContains(voice, 'Recognition runs locally in this browser')
+        self.assertNotContains(voice, "browser vendor's speech service")
 
     def test_voice_is_a_real_hall_of_fame_mode(self):
         voice_entry = HallOfFameEntry.objects.create(

--- a/brainrot/test_voice.py
+++ b/brainrot/test_voice.py
@@ -1,0 +1,100 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from .models import HallOfFameEntry
+
+
+class VoiceSpeedrunPageTests(TestCase):
+    def test_index_and_voice_page_expose_the_new_game(self):
+        index = self.client.get('/67/')
+        self.assertEqual(index.status_code, 200)
+        self.assertContains(index, '/67/voice/')
+        self.assertContains(index, 'Six Seven Voice Speedrun')
+
+        voice = self.client.get('/67/voice/')
+        self.assertEqual(voice.status_code, 200)
+        self.assertContains(voice, 'id="voice-app"')
+        self.assertContains(voice, 'data-game-mode="voice_67"')
+        self.assertContains(voice, 'voice_counter.js')
+        self.assertContains(voice, 'Recognizer transcript')
+        self.assertContains(voice, 'camera + microphone')
+
+    def test_voice_is_a_real_hall_of_fame_mode(self):
+        voice_entry = HallOfFameEntry.objects.create(
+            display_name='Fast Mouth',
+            game_mode=HallOfFameEntry.GameMode.VOICE_67,
+            score=12,
+            video='hall_of_fame/voice.webm',
+            mime_type='video/webm',
+            duration_seconds=23.25,
+            event_timeline=[round(index * 1.5, 3) for index in range(1, 13)],
+            visibility=HallOfFameEntry.Visibility.PUBLIC,
+        )
+        HallOfFameEntry.objects.create(
+            display_name='Arms Only',
+            game_mode=HallOfFameEntry.GameMode.SIX_SEVEN,
+            score=99,
+            video='hall_of_fame/arms.webm',
+            mime_type='video/webm',
+            duration_seconds=23.25,
+            event_timeline=[],
+            visibility=HallOfFameEntry.Visibility.PUBLIC,
+        )
+
+        response = self.client.get('/67/hall-of-fame/?mode=voice_67')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, 'Voice 67 Hall of Fame')
+        self.assertContains(response, 'Fast Mouth')
+        self.assertContains(response, 'said “six seven” 12 times')
+        self.assertNotContains(response, 'Arms Only')
+        self.assertContains(response, f'/67/voice/?rival={voice_entry.id}')
+
+    def test_generic_challenge_dispatches_voice_but_preserves_pose_runner(self):
+        voice_entry = HallOfFameEntry.objects.create(
+            display_name='Voice Rival',
+            game_mode=HallOfFameEntry.GameMode.VOICE_67,
+            score=3,
+            video='hall_of_fame/voice-rival.webm',
+            mime_type='video/webm',
+            duration_seconds=23.25,
+            event_timeline=[3.0, 6.0, 9.0],
+            visibility=HallOfFameEntry.Visibility.PUBLIC,
+        )
+        pose_entry = HallOfFameEntry.objects.create(
+            display_name='Pose Rival',
+            game_mode=HallOfFameEntry.GameMode.SIX_SEVEN,
+            score=2,
+            video='hall_of_fame/pose-rival.webm',
+            mime_type='video/webm',
+            duration_seconds=23.25,
+            event_timeline=[5.0, 10.0],
+            visibility=HallOfFameEntry.Visibility.PUBLIC,
+        )
+
+        voice_challenge = self.client.get(f'/67/challenge/{voice_entry.id}/')
+        self.assertRedirects(
+            voice_challenge,
+            f'/67/voice/?rival={voice_entry.id}',
+            fetch_redirect_response=False,
+        )
+
+        pose_challenge = self.client.get(f'/67/challenge/{pose_entry.id}/')
+        self.assertEqual(pose_challenge.status_code, 200)
+        self.assertContains(pose_challenge, 'id="counter-app"')
+        self.assertContains(pose_challenge, 'Pose Rival')
+
+    def test_voice_challenge_rejects_non_voice_rival_parameter(self):
+        user = get_user_model().objects.create_user('pose-user')
+        pose_entry = HallOfFameEntry.objects.create(
+            user=user,
+            game_mode=HallOfFameEntry.GameMode.LEG_CLAPS,
+            score=4,
+            video='hall_of_fame/leg-rival.webm',
+            mime_type='video/webm',
+            duration_seconds=23.25,
+            event_timeline=[2.0, 4.0, 6.0, 8.0],
+            visibility=HallOfFameEntry.Visibility.PUBLIC,
+        )
+
+        response = self.client.get(f'/67/voice/?rival={pose_entry.id}')
+        self.assertEqual(response.status_code, 404)

--- a/brainrot/urls.py
+++ b/brainrot/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 from django.views.generic import RedirectView
 from django.views.i18n import JavaScriptCatalog
 
-from . import views
+from . import views, voice_views
 
 app_name = 'brainrot'
 
@@ -10,6 +10,7 @@ urlpatterns = [
     path('jsi18n/', JavaScriptCatalog.as_view(), name='javascript_catalog'),
     path('', views.index, name='index'),
     path('counter/', views.counter, name='counter'),
+    path('voice/', voice_views.voice_counter, name='voice_counter'),
     path('games/', RedirectView.as_view(pattern_name='brainrot:index', permanent=True), name='games_legacy'),
     path('submit/', views.submit_hall_of_fame, name='submit_hall_of_fame'),
     path('hall-of-fame/', views.hall_of_fame, name='hall_of_fame'),

--- a/brainrot/urls.py
+++ b/brainrot/urls.py
@@ -19,6 +19,6 @@ urlpatterns = [
     path('hall-of-fame/<int:entry_id>/video/', views.hall_of_fame_video, name='hall_of_fame_video'),
     path('hall-of-fame/<int:entry_id>/visibility/', views.set_hall_of_fame_visibility, name='set_hall_of_fame_visibility'),
     path('hall-of-fame/<int:entry_id>/delete/', views.delete_hall_of_fame_entry, name='delete_hall_of_fame_entry'),
-    path('challenge/<int:entry_id>/', views.challenge, name='challenge'),
+    path('challenge/<int:entry_id>/', voice_views.challenge_dispatch, name='challenge'),
     path('typing/', views.typing_test, name='typing_test'),
 ]

--- a/brainrot/voice_views.py
+++ b/brainrot/voice_views.py
@@ -1,5 +1,6 @@
 from django.conf import settings
-from django.shortcuts import get_object_or_404, render
+from django.shortcuts import get_object_or_404, redirect, render
+from django.urls import reverse
 from django.views.decorators.csrf import ensure_csrf_cookie
 
 from .models import HallOfFameEntry
@@ -36,3 +37,17 @@ def voice_counter(request):
         })
 
     return render(request, 'brainrot/voice_counter.html', context)
+
+
+def challenge_dispatch(request, entry_id):
+    rival = get_object_or_404(
+        HallOfFameEntry.objects.only('id', 'game_mode', 'visibility'),
+        pk=entry_id,
+        visibility=HallOfFameEntry.Visibility.PUBLIC,
+    )
+    if rival.game_mode == HallOfFameEntry.GameMode.VOICE_67:
+        return redirect(f"{reverse('brainrot:voice_counter')}?rival={rival.pk}")
+
+    # Keep the mature pose challenge path exactly as-is for the two camera modes.
+    from . import views
+    return views.challenge(request, entry_id)

--- a/brainrot/voice_views.py
+++ b/brainrot/voice_views.py
@@ -1,0 +1,38 @@
+from django.conf import settings
+from django.shortcuts import get_object_or_404, render
+from django.views.decorators.csrf import ensure_csrf_cookie
+
+from .models import HallOfFameEntry
+
+
+@ensure_csrf_cookie
+def voice_counter(request):
+    rival = None
+    rival_id = request.GET.get('rival')
+    if rival_id:
+        rival = get_object_or_404(
+            HallOfFameEntry.objects.select_related('user'),
+            pk=rival_id,
+            game_mode=HallOfFameEntry.GameMode.VOICE_67,
+            visibility=HallOfFameEntry.Visibility.PUBLIC,
+        )
+
+    context = {
+        'turnstile_enabled': settings.TURNSTILE_ENABLED,
+        'turnstile_site_key': settings.TURNSTILE_SITE_KEY,
+        'max_upload_mb': settings.HOF_MAX_UPLOAD_BYTES // (1024 * 1024),
+        'anonymous_submission_available': settings.TURNSTILE_ENABLED or settings.DEBUG,
+        'rival': rival,
+        'game_mode': HallOfFameEntry.GameMode.VOICE_67,
+    }
+    if rival is not None:
+        timeline = rival.event_timeline
+        timeline_exact = len(timeline) == rival.score
+        if not timeline_exact and rival.score:
+            timeline = [round((index + 1) * 20 / (rival.score + 1), 3) for index in range(rival.score)]
+        context.update({
+            'rival_timeline': timeline,
+            'rival_timeline_exact': timeline_exact,
+        })
+
+    return render(request, 'brainrot/voice_counter.html', context)


### PR DESCRIPTION
## What this adds

A third formal 20-second Hall of Fame game: **Six Seven Voice Speedrun**.

The goal is deliberately strict: say **“six seven”** as many times as possible while remaining clear enough for the same local model to resolve the words in the correct order. Fast mumbling is not fuzzily rescued.

## Local recognition / scoring

This PR no longer uses the browser `SpeechRecognition` service.

- Firefox, Chrome and Edge all use the **same Vosk WASM recogniser** in the browser.
- The recogniser runs in a Web Worker and receives microphone audio locally.
- The grammar is deliberately restricted to `six`, `seven`, and `[unk]`.
- Only adjacent literal `six seven` pairs count.
- `[unk]`, reversed/incomplete words, `sixty seven`, fused guesses, and numeric text do not count.
- Live partial recognition may revise the displayed score; the score follows those revisions rather than permanently banking a mistaken partial.
- At exactly 20 seconds, microphone samples stop being fed to the recogniser and the evidence recording is stopped immediately. The worker then receives `retrieveFinalResult()` to flush only audio already received before the deadline.
- If finalisation unexpectedly times out, only complete literal pairs present in the last local partial snapshot are kept; there is still no fuzzy reconstruction.

The Vosk runtime is pinned to `vosk-browser@0.0.8`. The small English model is the Apache-2.0 `vosk-model-small-en-us-0.15`, repackaged as the `.tar.gz` format required by vosk-browser. It is roughly 40 MB and is downloaded only on the Voice page; it is not stored in this repository or on the Raspberry Pi.

## Architecture

- Voice is a new `HallOfFameEntry.GameMode.VOICE_67`, with migration `0006`.
- Existing HOF submission, privacy controls, video validation, rate limiting, Turnstile, storage and leaderboard filtering are reused.
- Voice has a separate frontend runner (`voice_counter.js`) plus a small local-recognition adapter (`voice_vosk.js`).
- Existing `counter.js` and `gesture_engine.js` are untouched.
- `/67/challenge/<id>/` dispatches Voice entries to the Voice runner while preserving the original pose challenge path for 67/Tung Tung.

## Evidence recording

Voice runs request **camera + microphone**. The local evidence recording contains camera video, microphone audio, live score HUD and countdown/timer.

Nothing uploads until the existing publication-consent flow is confirmed. The Voice consent copy explicitly says microphone audio will become public.

Challenge opponent videos are always **muted during the live run** so a rival recording cannot be re-heard by the contestant microphone and counted.

The shared MP4 exporter no longer discards audio tracks, so Voice evidence keeps microphone audio when WebM is converted for download. Pose recordings have no audio track and continue behaving as before.

## Privacy

Recognition itself is local: microphone audio is fed to the downloaded WASM model in the browser and is not sent to a speech-recognition service. The page discloses the initial ~40 MB model download separately from publication of the optional evidence recording.

## Validation performed

- strict local-token parser tests: **6/6 passed** under Node
  - repeated literal pairs
  - punctuation normalisation
  - `[unk]` breaks a pair
  - numbers / `sixty seven` / fused and incomplete forms are rejected
  - greedy adjacent-pair counting
  - repeated `six` cannot manufacture an extra pair
- `node --check` passes for the local Vosk adapter and Voice runner.
- Django regression coverage remains in `brainrot/test_voice.py` for Voice page/index exposure, HOF mode isolation, Voice challenge dispatch, preservation of the pose challenge runner, and rejection of non-Voice rivals.
- Diff review confirms **no changes** to `counter.js` or `gesture_engine.js`.

## Required browser smoke test before merge

This PR remains draft because the actual acoustic behaviour needs a real microphone/browser pass:

1. Firefox and Chrome/Edge both load the Vosk WASM runtime and model successfully.
2. Normal `six seven` repetitions count sensibly.
3. Rapid continuous `sixsevensixsevensixseven...` establishes the real recognition speed ceiling and does not stall the UI.
4. Deliberately unclear speech tends to become `[unk]` / missed words instead of free points.
5. The 20-second boundary does not count speech started after the deadline, while a phrase completed just before the boundary can still be flushed by `retrieveFinalResult()`.
6. A run records playable camera **and microphone audio**, HOF upload accepts it, and challenge replay remains muted.
7. Downloading the evidence as MP4 preserves microphone audio.

The old Chrome-only `SpeechRecognition` prototype has been removed from the Voice runner.