### PR TITLE
Make Voice 67 scoring forgiving and monotonic

### DIFF
--- a/brainrot/js_tests/voice_engine.test.mjs
+++ b/brainrot/js_tests/voice_engine.test.mjs
@@ -6,7 +6,11 @@ const source = await readFile(
   new URL('../static/brainrot/voice_engine.js', import.meta.url),
   'utf8',
 );
-const { countSixSevenPhrases, normaliseVoiceTranscript } = await import(
+const {
+  MonotonicVoiceScorer,
+  countSixSevenPhrases,
+  normaliseVoiceTranscript,
+} = await import(
   `data:text/javascript;base64,${Buffer.from(source).toString('base64')}`
 );
 
@@ -18,18 +22,31 @@ test('counts explicit repeated six seven pairs', () => {
   assert.equal(countSixSevenPhrases('six seven six seven six seven'), 3);
 });
 
-test('unknown speech breaks a pair', () => {
-  assert.equal(countSixSevenPhrases('six [unk] seven six seven'), 1);
+test('allows exactly one unknown between six and seven', () => {
+  assert.equal(countSixSevenPhrases('six [unk] seven six seven'), 2);
+  assert.equal(countSixSevenPhrases('six [unk] [unk] seven'), 0);
 });
 
 test('does not count numbers, sixty seven, fused words, or incomplete pairs', () => {
   assert.equal(countSixSevenPhrases('6 7 67 sixty seven sixseven six'), 0);
 });
 
-test('greedily counts only complete adjacent pairs', () => {
+test('greedily counts only complete ordered pairs', () => {
   assert.equal(countSixSevenPhrases('seven six seven six six seven seven'), 2);
 });
 
 test('extra six tokens do not manufacture an extra pair', () => {
   assert.equal(countSixSevenPhrases('six six seven six seven'), 2);
+});
+
+test('partial revisions never subtract an awarded point or double count one segment', () => {
+  const scorer = new MonotonicVoiceScorer();
+
+  assert.equal(scorer.observePartial('six seven'), 1);
+  assert.equal(scorer.observePartial('six'), 1);
+  assert.equal(scorer.observePartial('six seven'), 1);
+  assert.equal(scorer.commitFinal('six'), 1);
+
+  assert.equal(scorer.observePartial('six [unk] seven'), 2);
+  assert.equal(scorer.commitFinal('six seven'), 2);
 });

--- a/brainrot/static/brainrot/voice_counter.js
+++ b/brainrot/static/brainrot/voice_counter.js
@@ -1,5 +1,5 @@
 import { installMp4Download } from './mp4_download.js';
-import { countSixSevenPhrases } from './voice_engine.js';
+import { MonotonicVoiceScorer } from './voice_engine.js';
 import {
   SixSevenLocalRecognizer,
   loadSixSevenVoiceModel,
@@ -72,6 +72,7 @@ if (app) {
   let rivalTimelineIndex = 0;
   let committedSegments = [];
   let partialSegment = '';
+  const voiceScorer = new MonotonicVoiceScorer();
 
   let recorder = null;
   let recordingStream = null;
@@ -100,40 +101,29 @@ if (app) {
     errorEl.textContent = message || '';
   }
 
-  function recognisedText({ includePartial = true } = {}) {
-    const parts = [...committedSegments];
-    if (includePartial && partialSegment) parts.push(partialSegment);
-    return parts.filter(Boolean).join(' ').trim();
-  }
-
   function updateRecognitionUI() {
     heardFinal.textContent = committedSegments.join(' ').trim() || '—';
     heardInterim.textContent = partialSegment ? `… ${partialSegment}` : '';
   }
 
-  function syncScore({ includePartial = true } = {}) {
-    const nextScore = countSixSevenPhrases(recognisedText({ includePartial }));
-    if (nextScore !== score) {
-      if (nextScore < score) {
-        eventTimeline.length = nextScore;
-      } else {
-        const elapsed = runStartedAt
-          ? Math.min(GAME_SECONDS, Math.max(0, (performance.now() - runStartedAt) / 1000))
-          : 0;
-        while (eventTimeline.length < nextScore) {
-          eventTimeline.push(Number(elapsed.toFixed(3)));
-        }
-      }
-      score = nextScore;
-      scoreEl.textContent = String(score);
+  function lockScore(nextScore) {
+    if (nextScore <= score) return;
+
+    const elapsed = runStartedAt
+      ? Math.min(GAME_SECONDS, Math.max(0, (performance.now() - runStartedAt) / 1000))
+      : 0;
+    while (eventTimeline.length < nextScore) {
+      eventTimeline.push(Number(elapsed.toFixed(3)));
     }
+    score = nextScore;
+    scoreEl.textContent = String(score);
   }
 
   function handlePartial(text) {
     if (!running && !finalising) return;
     partialSegment = text || '';
     updateRecognitionUI();
-    syncScore({ includePartial: true });
+    lockScore(voiceScorer.observePartial(partialSegment));
   }
 
   function handleResult(text) {
@@ -141,7 +131,7 @@ if (app) {
     if (text) committedSegments.push(text);
     partialSegment = '';
     updateRecognitionUI();
-    syncScore({ includePartial: false });
+    lockScore(voiceScorer.commitFinal(text || ''));
   }
 
   async function ensureVoiceModel() {
@@ -414,6 +404,7 @@ if (app) {
     eventTimeline = [];
     committedSegments = [];
     partialSegment = '';
+    voiceScorer.reset();
     runStartedAt = 0;
     endTime = 0;
     rivalTimelineIndex = 0;
@@ -456,7 +447,7 @@ if (app) {
     if (rivalVideo && Math.abs(rivalVideo.currentTime - RECORDING_LEAD_SECONDS) > 0.35) {
       rivalVideo.currentTime = RECORDING_LEAD_SECONDS;
     }
-    setStatus(tr('Listening locally — say six seven'), 'ready');
+    setStatus(tr('Listening locally — clear 67s lock in immediately'), 'ready');
     gameLoop = requestAnimationFrame(updateGameClock);
   }
 
@@ -469,7 +460,7 @@ if (app) {
     timeEl.textContent = '0.0';
     rivalVideo?.pause();
     if (rivalScoreEl) rivalScoreEl.textContent = String(rivalFinalScore);
-    setStatus(tr('Time — locking the local model result…'), 'busy');
+    setStatus(tr('Time — locking the last local model result…'), 'busy');
 
     // Stop evidence at the deadline. The worker may take a moment to flush
     // already-received audio, but no post-deadline microphone samples are fed.
@@ -477,14 +468,14 @@ if (app) {
     const finalResultPromise = localRecognizer?.finalise(1500) || Promise.resolve('');
     const [blob] = await Promise.all([recordingPromise, finalResultPromise]);
 
-    // If the worker timed out without a final event, keep only complete pairs
-    // visible in its last local partial snapshot. No fuzzy reconstruction.
-    syncScore({ includePartial: true });
+    // If the worker timed out without a final event, lock the best complete
+    // pair count already seen in the last partial. Awarded points never roll back.
+    lockScore(voiceScorer.commitFinal(''));
     finalising = false;
     localRecognizer?.remove();
     localRecognizer = null;
 
-    setStatus(tr('Run complete — local voice result locked'), 'ready');
+    setStatus(tr('Run complete — awarded voice points are locked'), 'ready');
     resultScore.textContent = String(score);
     resultCopy.textContent = rivalName
       ? score > rivalFinalScore
@@ -492,7 +483,7 @@ if (app) {
         : score === rivalFinalScore
           ? `You tied ${rivalName}.`
           : `${rivalName} is ahead by ${rivalFinalScore - score}.`
-      : `Counted ${score} clear six sevens.`;
+      : `Counted ${score} six sevens.`;
     shareText.value = shareableResult();
     copyShareStatus.textContent = '';
     resultCard.hidden = false;
@@ -563,6 +554,7 @@ if (app) {
     eventTimeline = [];
     committedSegments = [];
     partialSegment = '';
+    voiceScorer.reset();
     runStartedAt = 0;
     endTime = 0;
     rivalTimelineIndex = 0;

--- a/brainrot/static/brainrot/voice_engine.js
+++ b/brainrot/static/brainrot/voice_engine.js
@@ -13,11 +13,54 @@ export function countSixSevenPhrases(value) {
 
   const tokens = normalised.split(/\s+/);
   let count = 0;
-  for (let index = 0; index + 1 < tokens.length; index += 1) {
-    if (tokens[index] === 'six' && tokens[index + 1] === 'seven') {
+  for (let index = 0; index < tokens.length; index += 1) {
+    if (tokens[index] !== 'six') continue;
+
+    if (tokens[index + 1] === 'seven') {
       count += 1;
       index += 1;
+      continue;
+    }
+
+    // Be slightly forgiving when the acoustic model inserts exactly one
+    // unknown token between a clearly recognised "six" and "seven".
+    if (tokens[index + 1] === '[unk]' && tokens[index + 2] === 'seven') {
+      count += 1;
+      index += 2;
     }
   }
   return count;
+}
+
+export class MonotonicVoiceScorer {
+  constructor() {
+    this.reset();
+  }
+
+  reset() {
+    this.committedScore = 0;
+    this.currentSegmentBest = 0;
+  }
+
+  get score() {
+    return this.committedScore + this.currentSegmentBest;
+  }
+
+  observePartial(value) {
+    this.currentSegmentBest = Math.max(
+      this.currentSegmentBest,
+      countSixSevenPhrases(value),
+    );
+    return this.score;
+  }
+
+  commitFinal(value = '') {
+    this.currentSegmentBest = Math.max(
+      this.currentSegmentBest,
+      countSixSevenPhrases(value),
+    );
+    this.committedScore += this.currentSegmentBest;
+    this.currentSegmentBest = 0;
+    return this.score;
+  }
 }

--- a/brainrot/templates/brainrot/voice_counter.html
+++ b/brainrot/templates/brainrot/voice_counter.html
@@ -32,7 +32,7 @@
     {% else %}
       <span class="badge text-bg-danger mode-badge mb-2">20 seconds · local voice model</span>
       <h1 class="display-5 mb-2">{% translate "Six Seven Voice Speedrun" %}</h1>
-      <p class="lead text-secondary mb-0">{% translate "Say “six seven” as many times as possible in 20 seconds. Only complete pairs that the local model clearly resolves as six then seven count." %}</p>
+      <p class="lead text-secondary mb-0">{% translate "Say “six seven” as many times as possible in 20 seconds. A clear six then seven counts; one unclear word between them is tolerated." %}</p>
     {% endif %}
   </header>
 
@@ -85,7 +85,7 @@
               <div class="text-secondary small text-uppercase fw-semibold mb-1">{% translate "Local model hearing" %}</div>
               <div id="heard-final" class="fw-semibold" aria-live="polite">—</div>
               <div id="heard-interim" class="text-secondary small mt-1"></div>
-              <p class="small text-secondary mb-0 mt-2">{% translate "The live line can revise itself while you speak. At 20 seconds the same local model is forced to finalise all audio received before the deadline." %}</p>
+              <p class="small text-secondary mb-0 mt-2">{% translate "The live recognition refreshes as the local model hears words. Once it has recognised a valid six-seven pair, that point is locked and later revisions never subtract it." %}</p>
             </div>
           </section>
         </div>
@@ -114,7 +114,7 @@
           <button class="btn btn-danger" id="start-run" disabled hidden>{% translate "Loading local voice model…" %}</button>
           <button class="btn btn-outline-secondary" id="reset-run" hidden>{% translate "Try again" %}</button>
         </div>
-        <p class="small text-secondary mt-3 mb-0">{% translate "The grammar is deliberately tiny: six, seven, and unknown. Speak fast, but if the model hears an unknown or the order is wrong, it does not count." %}</p>
+        <p class="small text-secondary mt-3 mb-0">{% translate "The grammar is deliberately tiny: six, seven, and unknown. Both “six seven” and “six [unknown] seven” count; missing or reversed words do not. Awarded points never decrease." %}</p>
         <p class="counter-error text-danger small mt-2 mb-0" id="voice-error" role="alert"></p>
       </section>
 


### PR DESCRIPTION
## Follow-up to #27

This adjusts the Voice 67 scoring rule after the local Vosk version landed.

### Scoring changes

- `six seven` still counts as 1.
- `six [unk] seven` now also counts as 1, tolerating one unclear token between an otherwise clear ordered pair.
- Two or more unknown tokens still do not bridge a pair.
- Missing/reversed words, `sixty seven`, numeric text and fused guesses still do not count.

### No score rollback

Voice scoring is now monotonic during a run:

- live Vosk partial results refresh the recognised text as before;
- as soon as a partial contains a valid pair, the point is awarded immediately;
- later partial/final revisions can never subtract an awarded point;
- each Vosk recognition segment tracks its historical best pair count, so repeated partial callbacks do not repeatedly award the same pair;
- when a segment finalises, only that segment's best count is committed, then the next segment starts fresh.

This avoids the unpleasant live `23 -> 21 -> 22` behaviour while still letting the local recogniser update as quickly as it produces partial words.

### Boundary behaviour

At 20 seconds the microphone feed and evidence recording still stop immediately. The final local worker flush may add a pair that was already present in pre-deadline audio, but it cannot remove points already awarded.

### Validation

- added parser coverage for `six [unk] seven` and rejection of `six [unk] [unk] seven`;
- added a monotonic scorer regression covering partial rollback, repeated partials and a new recognition segment after a locked false partial;
- local scorer smoke checks passed;
- diff is limited to `voice_engine.js`, `voice_counter.js`, its JS tests and Voice UI copy.

Real microphone testing is still useful to see how quickly Vosk emits partial words during an actual 20-second speedrun.