### PR TITLE
Experiment with word-level Voice 67 detection

### DIFF
--- a/brainrot/js_tests/voice_words.test.mjs
+++ b/brainrot/js_tests/voice_words.test.mjs
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const source = await readFile(
+  new URL('../static/brainrot/voice_words.js', import.meta.url),
+  'utf8',
+);
+const { SixSevenWordPairDetector } = await import(
+  `data:text/javascript;base64,${Buffer.from(source).toString('base64')}`
+);
+
+function detector() {
+  return new SixSevenWordPairDetector({
+    sixIndex: 0,
+    sevenIndex: 1,
+    minTargetScore: 0.30,
+    minTargetShareOfGlobal: 0.55,
+    minTargetMargin: 0.05,
+    pairTimeoutMs: 1000,
+    minRearmAfterCountMs: 70,
+    minPairIntervalMs: 180,
+  });
+}
+
+const six = [0.72, 0.08, 0.20];
+const seven = [0.09, 0.70, 0.21];
+const unknown = [0.12, 0.10, 0.78];
+
+test('a six followed by seven counts exactly one pair', () => {
+  const d = detector();
+  assert.equal(d.observe(six, 0).counted, false);
+  assert.equal(d.observe(seven, 100).counted, true);
+  assert.equal(d.observe(seven, 200).counted, false);
+});
+
+test('unknown windows between six and seven do not erase the armed pair', () => {
+  const d = detector();
+  d.observe(six, 0);
+  assert.equal(d.observe(unknown, 80).counted, false);
+  assert.equal(d.observe(seven, 160).counted, true);
+});
+
+test('rapid repeated six-seven pairs can count without phrase-level reset delay', () => {
+  const d = detector();
+  const hits = [];
+  for (const [time, scores] of [
+    [0, six], [100, seven], [180, six], [280, seven],
+    [360, six], [460, seven], [540, six], [640, seven],
+  ]) {
+    if (d.observe(scores, time).counted) hits.push(time);
+  }
+  assert.deepEqual(hits, [100, 280, 460, 640]);
+});
+
+test('low target confidence or a much stronger competing class does not arm', () => {
+  const d = detector();
+  assert.equal(d.observe([0.22, 0.05, 0.73], 0).word, '');
+  assert.equal(d.observe([0.31, 0.04, 0.90], 100).word, '');
+  assert.equal(d.observe(seven, 200).counted, false);
+});
+
+test('stale six expires instead of pairing with a much later seven', () => {
+  const d = detector();
+  d.observe(six, 0);
+  assert.equal(d.observe(seven, 1200).counted, false);
+});

--- a/brainrot/static/brainrot/voice_vosk.js
+++ b/brainrot/static/brainrot/voice_vosk.js
@@ -1,7 +1,8 @@
-// Compatibility shim for the existing Voice runner. The implementation moved
-// from general-purpose Vosk ASR to a dedicated sherpa-onnx keyword spotter.
+// Compatibility facade for voice_counter.js. Voice scoring now uses the
+// TensorFlow.js Speech Commands word classifier rather than transcript ASR or
+// whole-phrase wake-word spotting.
 export {
   SixSevenLocalRecognizer,
   loadSixSevenVoiceModel,
   releaseSixSevenVoiceModel,
-} from './voice_kws.js';
+} from './voice_words.js';

--- a/brainrot/static/brainrot/voice_words.js
+++ b/brainrot/static/brainrot/voice_words.js
@@ -174,6 +174,14 @@ export class SixSevenLocalRecognizer {
       sixIndex: model.sixIndex,
       sevenIndex: model.sevenIndex,
     });
+    // voice_counter.js historically creates a recognizer synchronously and
+    // then spends 3.25 s in its countdown. Start the TF.js-owned microphone
+    // pipeline immediately so it is warm before GO without rewriting that
+    // mature runner.
+    this.startPromise = this.start().catch((error) => {
+      this.handlers.onError?.(error);
+      throw error;
+    });
   }
 
   async start() {
@@ -211,6 +219,11 @@ export class SixSevenLocalRecognizer {
   acceptWaveform() {}
 
   async finalise() {
+    try {
+      await this.startPromise;
+    } catch {
+      return '';
+    }
     if (!this.listening) return '';
     try {
       await this.model.recognizer.stopListening();
@@ -230,8 +243,6 @@ export class SixSevenLocalRecognizer {
 }
 
 export function releaseSixSevenVoiceModel() {
-  // Keep the warmed TF.js model for the life of the page. It is small, and
-  // releasing it here would force a full network/model warm-up on every retry.
   loadedModel = null;
   modelPromise = null;
 }

--- a/brainrot/static/brainrot/voice_words.js
+++ b/brainrot/static/brainrot/voice_words.js
@@ -1,0 +1,237 @@
+const TFJS_VERSION = '4.22.0';
+const SPEECH_COMMANDS_VERSION = '0.5.4';
+const TFJS_URL = `https://cdn.jsdelivr.net/npm/@tensorflow/tfjs@${TFJS_VERSION}/dist/tf.min.js`;
+const SPEECH_COMMANDS_URL = `https://cdn.jsdelivr.net/npm/@tensorflow-models/speech-commands@${SPEECH_COMMANDS_VERSION}/dist/speech-commands.min.js`;
+
+const MIN_TARGET_SCORE = 0.30;
+const MIN_TARGET_SHARE_OF_GLOBAL = 0.55;
+const MIN_TARGET_MARGIN = 0.05;
+const PAIR_TIMEOUT_MS = 1000;
+const MIN_REARM_AFTER_COUNT_MS = 70;
+const MIN_PAIR_INTERVAL_MS = 180;
+const OVERLAP_FACTOR = 0.90;
+
+let runtimePromise = null;
+let modelPromise = null;
+let loadedModel = null;
+
+function loadScript(url, marker) {
+  const attr = `data-${marker}`;
+  const existing = document.querySelector(`script[${attr}]`);
+  if (existing) {
+    if (existing.dataset.loaded === '1') return Promise.resolve();
+    return new Promise((resolve, reject) => {
+      existing.addEventListener('load', resolve, { once: true });
+      existing.addEventListener('error', () => reject(new Error(`Could not load ${url}`)), { once: true });
+    });
+  }
+
+  return new Promise((resolve, reject) => {
+    const script = document.createElement('script');
+    script.src = url;
+    script.async = false;
+    script.crossOrigin = 'anonymous';
+    script.setAttribute(attr, '1');
+    script.addEventListener('load', () => {
+      script.dataset.loaded = '1';
+      resolve();
+    }, { once: true });
+    script.addEventListener('error', () => reject(new Error(`Could not load ${url}`)), { once: true });
+    document.head.appendChild(script);
+  });
+}
+
+async function loadTfRuntime() {
+  if (window.tf && window.speechCommands) return;
+  if (runtimePromise) return runtimePromise;
+
+  runtimePromise = (async () => {
+    if (!window.tf) await loadScript(TFJS_URL, 'icaijy-tfjs');
+    if (!window.speechCommands) {
+      await loadScript(SPEECH_COMMANDS_URL, 'icaijy-speech-commands');
+    }
+    if (!window.tf || !window.speechCommands) {
+      throw new Error('The local word-recognition runtime did not initialise.');
+    }
+    await window.tf.ready();
+  })().catch((error) => {
+    runtimePromise = null;
+    throw error;
+  });
+
+  return runtimePromise;
+}
+
+export class SixSevenWordPairDetector {
+  constructor(options = {}) {
+    this.sixIndex = options.sixIndex;
+    this.sevenIndex = options.sevenIndex;
+    this.minTargetScore = options.minTargetScore ?? MIN_TARGET_SCORE;
+    this.minTargetShareOfGlobal = options.minTargetShareOfGlobal ?? MIN_TARGET_SHARE_OF_GLOBAL;
+    this.minTargetMargin = options.minTargetMargin ?? MIN_TARGET_MARGIN;
+    this.pairTimeoutMs = options.pairTimeoutMs ?? PAIR_TIMEOUT_MS;
+    this.minRearmAfterCountMs = options.minRearmAfterCountMs ?? MIN_REARM_AFTER_COUNT_MS;
+    this.minPairIntervalMs = options.minPairIntervalMs ?? MIN_PAIR_INTERVAL_MS;
+    this.reset();
+  }
+
+  reset() {
+    this.armedAt = null;
+    this.lastCountAt = -Infinity;
+    this.lastWord = '';
+  }
+
+  classify(scores) {
+    if (!scores || this.sixIndex == null || this.sevenIndex == null) return null;
+    const sixScore = Number(scores[this.sixIndex] || 0);
+    const sevenScore = Number(scores[this.sevenIndex] || 0);
+    let globalMax = 0;
+    for (const value of scores) globalMax = Math.max(globalMax, Number(value) || 0);
+
+    const choose = (word, targetScore, otherScore) => {
+      if (targetScore < this.minTargetScore) return null;
+      if (targetScore + 1e-9 < globalMax * this.minTargetShareOfGlobal) return null;
+      if (targetScore - otherScore < this.minTargetMargin) return null;
+      return { word, targetScore, sixScore, sevenScore, globalMax };
+    };
+
+    return sixScore >= sevenScore
+      ? choose('six', sixScore, sevenScore)
+      : choose('seven', sevenScore, sixScore);
+  }
+
+  observe(scores, now = performance.now()) {
+    const classified = this.classify(scores);
+    const word = classified?.word || '';
+    this.lastWord = word;
+
+    if (this.armedAt !== null && now - this.armedAt > this.pairTimeoutMs) {
+      this.armedAt = null;
+    }
+
+    if (word === 'six') {
+      if (now - this.lastCountAt >= this.minRearmAfterCountMs) {
+        this.armedAt = now;
+      }
+      return { word, counted: false, classified };
+    }
+
+    if (word === 'seven' && this.armedAt !== null) {
+      if (now - this.lastCountAt >= this.minPairIntervalMs) {
+        this.armedAt = null;
+        this.lastCountAt = now;
+        return { word, counted: true, classified };
+      }
+    }
+
+    return { word, counted: false, classified };
+  }
+}
+
+export async function loadSixSevenVoiceModel(onStatus = () => {}) {
+  if (loadedModel?.ready) return loadedModel;
+  if (modelPromise) return modelPromise;
+
+  modelPromise = (async () => {
+    onStatus('Loading local six/seven word model…');
+    await loadTfRuntime();
+
+    const recognizer = window.speechCommands.create('BROWSER_FFT', '18w');
+    await recognizer.ensureModelLoaded();
+    const labels = recognizer.wordLabels();
+    const sixIndex = labels.indexOf('six');
+    const sevenIndex = labels.indexOf('seven');
+    if (sixIndex < 0 || sevenIndex < 0) {
+      throw new Error('The local word model does not contain six and seven.');
+    }
+
+    loadedModel = {
+      ready: true,
+      recognizer,
+      labels,
+      sixIndex,
+      sevenIndex,
+    };
+    onStatus('Local six/seven word model ready');
+    return loadedModel;
+  })().catch((error) => {
+    modelPromise = null;
+    throw error;
+  });
+
+  return modelPromise;
+}
+
+export class SixSevenLocalRecognizer {
+  constructor(model, _sampleRate, handlers = {}) {
+    if (!model?.ready || !model.recognizer) {
+      throw new Error('The local six/seven word model is not ready.');
+    }
+    this.model = model;
+    this.handlers = handlers;
+    this.listening = false;
+    this.detector = new SixSevenWordPairDetector({
+      sixIndex: model.sixIndex,
+      sevenIndex: model.sevenIndex,
+    });
+  }
+
+  async start() {
+    if (this.listening) return;
+    this.detector.reset();
+    await this.model.recognizer.listen((result) => {
+      try {
+        const observed = this.detector.observe(result.scores, performance.now());
+        this.handlers.onPartial?.(observed.word || '');
+        if (observed.counted) {
+          this.handlers.onResult?.('six seven', observed.classified || {});
+        }
+      } catch (error) {
+        this.handlers.onError?.(error);
+      }
+    }, {
+      probabilityThreshold: 0,
+      invokeCallbackOnNoiseAndUnknown: true,
+      overlapFactor: OVERLAP_FACTOR,
+      suppressionTimeMillis: 0,
+      includeSpectrogram: false,
+      audioTrackConstraints: {
+        echoCancellation: true,
+        noiseSuppression: true,
+        autoGainControl: true,
+        channelCount: 1,
+      },
+    });
+    this.listening = true;
+  }
+
+  // The TF.js recognizer owns its own WebAudio microphone pipeline. The
+  // existing Voice runner still calls this method for the old sherpa/Vosk
+  // adapters, so keep it as an intentional no-op compatibility hook.
+  acceptWaveform() {}
+
+  async finalise() {
+    if (!this.listening) return '';
+    try {
+      await this.model.recognizer.stopListening();
+    } finally {
+      this.listening = false;
+    }
+    return '';
+  }
+
+  remove() {
+    if (!this.listening) return;
+    this.model.recognizer.stopListening().catch((error) => {
+      console.debug('Voice word detector cleanup failed.', error);
+    });
+    this.listening = false;
+  }
+}
+
+export function releaseSixSevenVoiceModel() {
+  // Keep the warmed TF.js model for the life of the page. It is small, and
+  // releasing it here would force a full network/model warm-up on every retry.
+  loadedModel = null;
+  modelPromise = null;
+}

--- a/brainrot/static/brainrot/voice_words.js
+++ b/brainrot/static/brainrot/voice_words.js
@@ -170,17 +170,17 @@ export class SixSevenLocalRecognizer {
     this.model = model;
     this.handlers = handlers;
     this.listening = false;
+    this.active = false;
     this.detector = new SixSevenWordPairDetector({
       sixIndex: model.sixIndex,
       sevenIndex: model.sevenIndex,
     });
-    // voice_counter.js historically creates a recognizer synchronously and
-    // then spends 3.25 s in its countdown. Start the TF.js-owned microphone
-    // pipeline immediately so it is warm before GO without rewriting that
-    // mature runner.
+    // voice_counter.js creates the per-run recognizer before its 3.25-second
+    // countdown. Warm TF.js immediately, but gate scoring until the old PCM
+    // pipeline first calls acceptWaveform() after GO.
     this.startPromise = this.start().catch((error) => {
       this.handlers.onError?.(error);
-      throw error;
+      return undefined;
     });
   }
 
@@ -188,6 +188,7 @@ export class SixSevenLocalRecognizer {
     if (this.listening) return;
     this.detector.reset();
     await this.model.recognizer.listen((result) => {
+      if (!this.active) return;
       try {
         const observed = this.detector.observe(result.scores, performance.now());
         this.handlers.onPartial?.(observed.word || '');
@@ -213,17 +214,18 @@ export class SixSevenLocalRecognizer {
     this.listening = true;
   }
 
-  // The TF.js recognizer owns its own WebAudio microphone pipeline. The
-  // existing Voice runner still calls this method for the old sherpa/Vosk
-  // adapters, so keep it as an intentional no-op compatibility hook.
-  acceptWaveform() {}
+  // This call comes from the existing runner only while feedRecognizer=true.
+  // TF.js owns a separate local WebAudio stream; use the legacy callback solely
+  // as the exact game-window gate so countdown speech cannot pre-arm scoring.
+  acceptWaveform() {
+    if (this.active) return;
+    this.detector.reset();
+    this.active = true;
+  }
 
   async finalise() {
-    try {
-      await this.startPromise;
-    } catch {
-      return '';
-    }
+    this.active = false;
+    await this.startPromise;
     if (!this.listening) return '';
     try {
       await this.model.recognizer.stopListening();
@@ -234,6 +236,7 @@ export class SixSevenLocalRecognizer {
   }
 
   remove() {
+    this.active = false;
     if (!this.listening) return;
     this.model.recognizer.stopListening().catch((error) => {
       console.debug('Voice word detector cleanup failed.', error);


### PR DESCRIPTION
## Why this experiment

Real-browser testing of the sherpa-onnx whole-phrase KWS detector showed the important failure mode clearly: slow, separated `six seven` repetitions are recognised reliably, but rapid continuous `sixsevensixsevensixseven...` can miss roughly five out of six repetitions.

That makes whole-phrase wake-word spotting a poor fit for a speedrun whose skill is specifically continuous fast articulation. This PR deliberately changes the model family instead of continuing to tune sherpa thresholds.

## Approach

Use TensorFlow.js Speech Commands as a **word-level** streaming classifier:

- the pretrained `18w` vocabulary already contains native `six` and `seven` classes;
- every overlapping inference window exposes the full probability vector;
- the detector reads `P(six)` and `P(seven)` directly rather than relying only on the global argmax;
- a trusted `six` arms the counter;
- the next trusted `seven` awards exactly one point and disarms it;
- unknown/noisy windows may occur between the two without rolling back anything;
- stale `six` arms expire after 1 second;
- score events are monotonic and still flow through the existing Voice runner/HOF timeline.

The recognizer uses `overlapFactor: 0.90` with no suppression period, which means heavily overlapping roughly-one-second spectrogram windows and a prediction hop on the order of ~100 ms. This is intended to follow individual words rather than wait for phrase-final silence.

## Initial scoring gates

These are intentionally starting values for the browser A/B test, not claimed-final tuning:

- target class probability >= 0.30;
- target class >= 55% of the strongest class probability, so `_unknown_` may be somewhat stronger without automatically discarding a useful six/seven signal;
- six-vs-seven margin >= 0.05;
- minimum completed-pair interval 180 ms;
- minimum re-arm after a count 70 ms.

## Scope

- Adds `voice_words.js` and routes the existing `voice_vosk.js` compatibility facade to it.
- Does **not** change `voice_counter.js`, backend/HOF/upload/privacy/challenge code, or either pose detector.
- The old Voice runner still owns timing, evidence recording, score locking and HOF submission.
- TF.js owns a second local microphone/WebAudio stream for this experiment. Audio classification remains in-browser. If this detector wins the A/B test, the audio pipeline can be consolidated afterwards rather than prematurely optimising an unproven model.
- The existing runner's post-GO PCM callback is reused purely as an `active` gate, so the classifier may warm during the countdown but cannot score until the 20-second game window starts; `finalise()` disables scoring immediately at the deadline.

## Tests added

`voice_words.test.mjs` exercises the pure pair state machine:

- six -> seven counts once;
- repeated seven does not double-count;
- unknown windows do not erase an armed six;
- four rapid six/seven pairs can produce four events without phrase-level reset delay;
- low/ambiguous target confidence does not arm;
- a stale six expires.

These tests have not been executed in this environment; the important validation is a real microphone/browser speed test.

## Required A/B test before merge

Do not merge this based on slow speech alone. Test this branch against the sherpa version with the same speaker/browser:

1. clear separated `six seven` x10;
2. normal continuous repetitions x10;
3. maximum-speed continuous repetitions while manually counting the actual phrases;
4. random English / mumbling for obvious false positives;
5. Firefox first, then Chromium if convenient.

The deciding metric is rapid recall: if this does not materially beat the current sherpa result (~1 detection per 6 rapid phrases), reject it and keep researching rather than tuning around the wrong model.