### PR TITLE
Polish site UI, park Voice 67, and fix MP4 downloads

### DIFF
--- a/brainrot/admin.py
+++ b/brainrot/admin.py
@@ -23,7 +23,7 @@ class HallOfFameEntryAdmin(admin.ModelAdmin):
             return 'Save first'
         video_url = f'/67/hall-of-fame/{obj.pk}/video/'
         return format_html(
-            '<a href="{}" target="_blank">Open recording</a> · <a href="{}?download=1">Download</a>',
+            '<a href="{}" target="_blank">Open recording</a> · <a href="{}?download=1&amp;format=mp4">Download MP4</a>',
             video_url,
             video_url,
         )

--- a/brainrot/download_views.py
+++ b/brainrot/download_views.py
@@ -8,8 +8,8 @@ from .views import hall_of_fame_video as original_hall_of_fame_video
 
 
 def hall_of_fame_video(request, entry_id):
-    """Keep inline evidence untouched; normalise explicit downloads to MP4."""
-    if request.GET.get('download') != '1':
+    """Keep inline/legacy evidence untouched; normalise new downloads to MP4."""
+    if request.GET.get('format') != 'mp4':
         return original_hall_of_fame_video(request, entry_id)
 
     entry = get_object_or_404(HallOfFameEntry.objects.select_related('user'), pk=entry_id)

--- a/brainrot/download_views.py
+++ b/brainrot/download_views.py
@@ -1,0 +1,41 @@
+from django.http import FileResponse, JsonResponse
+from django.shortcuts import get_object_or_404
+from django.utils.translation import gettext as _
+
+from .models import HallOfFameEntry
+from .video_downloads import Mp4TranscodeError, open_compatible_mp4
+from .views import hall_of_fame_video as original_hall_of_fame_video
+
+
+def hall_of_fame_video(request, entry_id):
+    """Keep inline evidence untouched; normalise explicit downloads to MP4."""
+    if request.GET.get('download') != '1':
+        return original_hall_of_fame_video(request, entry_id)
+
+    entry = get_object_or_404(HallOfFameEntry.objects.select_related('user'), pk=entry_id)
+    may_view = (
+        entry.visibility == HallOfFameEntry.Visibility.PUBLIC
+        or entry.user_id == request.user.id
+        or request.user.is_superuser
+    )
+    if not may_view:
+        return JsonResponse({'error': _('Recording is not public.')}, status=404)
+
+    try:
+        handle, size = open_compatible_mp4(entry)
+    except Mp4TranscodeError as exc:
+        return JsonResponse({'error': str(exc)}, status=503)
+
+    if entry.game_mode == HallOfFameEntry.GameMode.LEG_CLAPS:
+        mode_slug = 'tung-tung-leg-claps'
+    elif entry.game_mode == HallOfFameEntry.GameMode.VOICE_67:
+        mode_slug = 'six-seven-voice'
+    else:
+        mode_slug = '67'
+
+    response = FileResponse(handle, content_type='video/mp4')
+    response['Content-Length'] = size
+    response['Content-Disposition'] = f'attachment; filename="{mode_slug}-run-{entry.pk}.mp4"'
+    response['X-Content-Type-Options'] = 'nosniff'
+    response['Cache-Control'] = 'private, no-store'
+    return response

--- a/brainrot/static/brainrot/hof_detail.js
+++ b/brainrot/static/brainrot/hof_detail.js
@@ -1,5 +1,3 @@
-import { installMp4Download } from './mp4_download.js';
-
 const detail = document.getElementById('hof-detail');
 if (detail) {
   const tr = (message) => typeof gettext === 'function' ? gettext(message) : message;
@@ -19,23 +17,9 @@ if (detail) {
     : isVoice
       ? `${detail.dataset.username} clearly said “six seven” ${score} times in 20 seconds! 🗣️`
       : `${detail.dataset.username} made ${score} 6️⃣7️⃣ moves in 20 seconds! 🔥`;
-  // This sentence is already translated by Django in the visible page copy.
   const headline = detail.querySelector('.pb-2 .fw-bold')?.textContent.trim() || fallbackHeadline;
   const text = `${headline}\n${blocks}\n${url}`;
   if (shareText) shareText.value = text;
-
-  const downloadButton = detail.querySelector('a[href*="?download=1"]');
-  const safeName = detail.dataset.username.replace(/[^a-z0-9_-]+/gi, '-').replace(/^-+|-+$/g, '') || 'run';
-  const downloadSlug = isLegClaps ? 'tung-tung-leg-claps' : isVoice ? 'six-seven-voice' : '67';
-  installMp4Download(downloadButton, {
-    filename: `${downloadSlug}-${safeName}-${score}.webm`,
-    onStatus(message) {
-      if (status) status.textContent = message;
-    },
-    onError(error) {
-      if (status) status.textContent = `MP4 download failed: ${error.message}`;
-    },
-  });
 
   async function copyShareMessage() {
     if (!shareText || !copyButton) return;

--- a/brainrot/templates/brainrot/hall_of_fame.html
+++ b/brainrot/templates/brainrot/hall_of_fame.html
@@ -97,7 +97,7 @@
               <p class="text-secondary small mt-2">{% translate "Open the detail page to share this run or download a phone-friendly MP4." %}</p>
               <div class="d-flex flex-wrap gap-2">
                 <a href="{% url 'brainrot:hall_of_fame_detail' entry.id %}">{% translate "Open full run" %} →</a>
-                <a href="{{ preview_url }}?download=1"><i class="fa-solid fa-download me-1"></i>{% translate "Download MP4" %}</a>
+                <a href="{{ preview_url }}?download=1&amp;format=mp4"><i class="fa-solid fa-download me-1"></i>{% translate "Download MP4" %}</a>
               </div>
             </div>
           </div>

--- a/brainrot/templates/brainrot/hall_of_fame.html
+++ b/brainrot/templates/brainrot/hall_of_fame.html
@@ -24,7 +24,7 @@
         {% if game_mode == 'leg_claps' %}
           {% translate "See who made the most inward knee claps in 20 seconds, watch each run, then challenge it yourself. Each clap requires the knees to open again before the next count." %}
         {% elif game_mode == 'voice_67' %}
-          {% translate "See who clearly said “six seven” the most times in 20 seconds. The recogniser only awards complete recognised pairs; the evidence video includes microphone audio." %}
+          {% translate "Historical Voice 67 runs remain watchable while the high-speed detector is rebuilt. New voice runs are temporarily coming soon." %}
         {% else %}
           {% translate "See who made the most 6️⃣7️⃣ moves in 20 seconds, watch each run, then challenge it yourself. Guest names are visibly labelled and cannot copy registered usernames." %}
         {% endif %}
@@ -34,21 +34,26 @@
       <div class="btn-group flex-wrap" role="group" aria-label="{% translate 'Leaderboard mode' %}">
         <a class="btn {% if game_mode == 'six_seven' %}btn-primary{% else %}btn-outline-primary{% endif %}" href="{% url 'brainrot:hall_of_fame' %}?mode=six_seven">67 Counter</a>
         <a class="btn {% if game_mode == 'leg_claps' %}btn-success{% else %}btn-outline-success{% endif %}" href="{% url 'brainrot:hall_of_fame' %}?mode=leg_claps">{% translate "Tung Tung Leg Claps" %}</a>
-        <a class="btn {% if game_mode == 'voice_67' %}btn-danger{% else %}btn-outline-danger{% endif %}" href="{% url 'brainrot:hall_of_fame' %}?mode=voice_67">{% translate "Voice 67" %}</a>
+        <a class="btn {% if game_mode == 'voice_67' %}btn-warning{% else %}btn-outline-warning{% endif %}" href="{% url 'brainrot:hall_of_fame' %}?mode=voice_67">{% translate "Voice 67" %}</a>
       </div>
     </div>
   </div>
+
+  {% if game_mode == 'voice_67' %}
+    <div class="alert alert-warning border-0 shadow-sm mb-4">
+      <strong>Voice 67 is being rebuilt.</strong> {% translate "The old leaderboard is preserved, but challenges and new submissions are paused until the purpose-built continuous-speech model is ready." %}
+      <a class="alert-link ms-1" href="{% url 'brainrot:voice_counter' %}">{% translate "Read the update" %} →</a>
+    </div>
+  {% endif %}
 
   <div class="d-grid gap-3">
     {% for entry in entries %}
     <article class="card shadow-sm">
       <div class="card-body p-3 p-md-4">
         <div class="row g-3 align-items-center">
-          <div class="col-auto">
-            <span class="badge text-bg-light border text-dark fs-6">#{{ forloop.counter }}</span>
-          </div>
+          <div class="col-auto"><span class="badge text-bg-light border text-dark fs-6">#{{ forloop.counter }}</span></div>
           <div class="col">
-            <h2 class="h5 border-0 ps-0 ms-0 mb-1">{{ entry.public_name }}</h2>
+            <h2 class="h5 mb-1">{{ entry.public_name }}</h2>
             <div class="text-secondary small">
               {% if entry.game_mode == 'leg_claps' %}
                 {% blocktranslate with score=entry.score date=entry.created_at|date:'j M Y' %}made {{ score }} leg claps in 20 seconds · {{ date }}{% endblocktranslate %}
@@ -68,7 +73,7 @@
         <div class="d-flex flex-wrap gap-2 mt-3">
           <a class="btn btn-sm btn-outline-dark" href="{% url 'brainrot:hall_of_fame_detail' entry.id %}">{% translate "Full details" %}</a>
           {% if entry.game_mode == 'voice_67' %}
-            <a class="btn btn-sm btn-danger" href="{% url 'brainrot:voice_counter' %}?rival={{ entry.id }}">{% translate "Challenge this run" %}</a>
+            <a class="btn btn-sm btn-outline-warning" href="{% url 'brainrot:voice_counter' %}">{% translate "Voice mode coming soon" %}</a>
           {% else %}
             <a class="btn btn-sm btn-primary" href="{% url 'brainrot:challenge' entry.id %}">{% translate "Challenge this run" %}</a>
           {% endif %}
@@ -78,9 +83,7 @@
         <details class="mt-3">
           <summary class="text-primary fw-semibold" style="cursor:pointer">{% translate "Watch video preview" %}</summary>
           <div class="row g-3 mt-1 align-items-start">
-            <div class="col-12 col-lg-6">
-              <video class="w-100 rounded bg-dark" controls preload="none" playsinline src="{{ preview_url }}"></video>
-            </div>
+            <div class="col-12 col-lg-6"><video class="w-100 rounded bg-dark" controls preload="none" playsinline src="{{ preview_url }}"></video></div>
             <div class="col-12 col-lg-6">
               <strong>
                 {% if entry.game_mode == 'leg_claps' %}
@@ -91,10 +94,10 @@
                   {% blocktranslate with name=entry.public_name score=entry.score %}{{ name }} made {{ score }} 6️⃣7️⃣ moves in 20 seconds.{% endblocktranslate %}
                 {% endif %}
               </strong>
-              <p class="text-secondary small mt-2">{% translate "Open the detail page to share this run, download it, or start a synchronized challenge." %}</p>
+              <p class="text-secondary small mt-2">{% translate "Open the detail page to share this run or download a phone-friendly MP4." %}</p>
               <div class="d-flex flex-wrap gap-2">
                 <a href="{% url 'brainrot:hall_of_fame_detail' entry.id %}">{% translate "Open full run" %} →</a>
-                <a href="{{ preview_url }}?download=1">{% translate "Download video" %}</a>
+                <a href="{{ preview_url }}?download=1"><i class="fa-solid fa-download me-1"></i>{% translate "Download MP4" %}</a>
               </div>
             </div>
           </div>
@@ -105,10 +108,10 @@
     {% empty %}
     <div class="card border-dashed">
       <div class="card-body p-4 text-center">
-        <h2 class="h4 border-0 ps-0 ms-0">{% translate "No legends yet." %}</h2>
+        <h2 class="h4">{% translate "No legends yet." %}</h2>
         <p class="text-secondary">{% translate "The scientific community has uploaded absolutely nothing." %}</p>
         {% if game_mode == 'voice_67' %}
-          <a href="{% url 'brainrot:voice_counter' %}" class="btn btn-danger">{% translate "Submit the first specimen" %}</a>
+          <a href="{% url 'brainrot:voice_counter' %}" class="btn btn-warning">{% translate "Voice mode coming soon" %}</a>
         {% else %}
           <a href="{% url 'brainrot:counter' %}?mode={{ game_mode }}" class="btn btn-primary">{% translate "Submit the first specimen" %}</a>
         {% endif %}

--- a/brainrot/templates/brainrot/hall_of_fame_detail.html
+++ b/brainrot/templates/brainrot/hall_of_fame_detail.html
@@ -35,6 +35,7 @@
       <div class="d-flex flex-wrap gap-2 mt-2">
         <span class="badge {% if entry.game_mode == 'leg_claps' %}text-bg-success{% elif entry.game_mode == 'voice_67' %}text-bg-danger{% else %}text-bg-primary{% endif %}">{{ entry.get_game_mode_display }}</span>
         <span class="badge {% if entry.visibility == 'public' %}text-bg-success{% else %}text-bg-secondary{% endif %}">{{ entry.get_visibility_display }}</span>
+        {% if entry.game_mode == 'voice_67' %}<span class="badge text-bg-warning">COMING SOON · detector rebuild</span>{% endif %}
       </div>
     </div>
   </div>
@@ -46,15 +47,16 @@
         <div class="card-body p-3">
           <video class="w-100 rounded bg-dark" controls preload="metadata" playsinline src="{{ evidence_url }}"></video>
           <div class="d-flex flex-wrap gap-2 mt-3">
-            <a class="btn btn-outline-secondary" href="{{ evidence_url }}?download=1">{% translate "Download counted video" %}</a>
+            <a class="btn btn-outline-secondary" href="{{ evidence_url }}?download=1"><i class="fa-solid fa-download me-1"></i> {% translate "Download MP4" %}</a>
             {% if entry.visibility == 'public' %}
               {% if entry.game_mode == 'voice_67' %}
-                <a class="btn btn-danger" href="{% url 'brainrot:voice_counter' %}?rival={{ entry.id }}">{% translate "Challenge this specimen" %}</a>
+                <a class="btn btn-outline-warning" href="{% url 'brainrot:voice_counter' %}">{% translate "Voice challenge coming soon" %}</a>
               {% else %}
                 <a class="btn btn-primary" href="{% url 'brainrot:challenge' entry.id %}">{% translate "Challenge this specimen" %}</a>
               {% endif %}
             {% endif %}
           </div>
+          <p class="small text-secondary mt-2 mb-0">{% translate "Downloads are served as H.264/AAC MP4 for broad phone compatibility." %}</p>
         </div>
       </div>
     </div>
@@ -63,7 +65,7 @@
       <aside class="card shadow-sm">
         <div class="card-body p-3 p-md-4">
           <div class="text-secondary small text-uppercase fw-semibold mb-2">{% if entry.visibility == 'public' %}{% translate "PUBLIC REPLICATION MATERIAL" %}{% else %}{% translate "PRIVATE OWNER VIEW" %}{% endif %}</div>
-          <h2 class="h4 border-0 ps-0 ms-0">{% if entry.visibility == 'public' %}{% translate "Share this run" %}{% else %}{% translate "Private run" %}{% endif %}</h2>
+          <h2 class="h4">{% if entry.visibility == 'public' %}{% translate "Share this run" %}{% else %}{% translate "Private run" %}{% endif %}</h2>
           {% if entry.visibility == 'private' %}
             <p class="text-secondary small">{% translate "Only you and site superusers can open this page or video. Publish it to restore its Hall of Fame listing and share link." %}</p>
           {% elif entry.user_id and request.user == entry.user %}
@@ -89,5 +91,5 @@
   </div>
 </main>
 <script src="{% url 'brainrot:javascript_catalog' %}"></script>
-<script type="module" src="{% static 'brainrot/hof_detail.js' %}?v=20260817.2"></script>
+<script type="module" src="{% static 'brainrot/hof_detail.js' %}"></script>
 {% endblock %}

--- a/brainrot/templates/brainrot/hall_of_fame_detail.html
+++ b/brainrot/templates/brainrot/hall_of_fame_detail.html
@@ -47,7 +47,7 @@
         <div class="card-body p-3">
           <video class="w-100 rounded bg-dark" controls preload="metadata" playsinline src="{{ evidence_url }}"></video>
           <div class="d-flex flex-wrap gap-2 mt-3">
-            <a class="btn btn-outline-secondary" href="{{ evidence_url }}?download=1"><i class="fa-solid fa-download me-1"></i> {% translate "Download MP4" %}</a>
+            <a class="btn btn-outline-secondary" href="{{ evidence_url }}?download=1&amp;format=mp4"><i class="fa-solid fa-download me-1"></i> {% translate "Download MP4" %}</a>
             {% if entry.visibility == 'public' %}
               {% if entry.game_mode == 'voice_67' %}
                 <a class="btn btn-outline-warning" href="{% url 'brainrot:voice_counter' %}">{% translate "Voice challenge coming soon" %}</a>
@@ -91,5 +91,5 @@
   </div>
 </main>
 <script src="{% url 'brainrot:javascript_catalog' %}"></script>
-<script type="module" src="{% static 'brainrot/hof_detail.js' %}"></script>
+<script type="module" src="{% static 'brainrot/hof_detail.js' %}?v=20260817.2"></script>
 {% endblock %}

--- a/brainrot/templates/brainrot/index.html
+++ b/brainrot/templates/brainrot/index.html
@@ -1,43 +1,56 @@
 {% extends 'base.html' %}
 {% load static i18n %}
+{% get_current_language as CURRENT_LANGUAGE %}
 
 {% block title %}67 Games{% endblock %}
 
 {% block content %}
+<style>
+  .games-hero-card {
+    overflow: hidden;
+    border: 1px solid #1e293b;
+    background: linear-gradient(135deg, #0b1220 0%, #111827 65%, #172033 100%);
+    color: #fff;
+    box-shadow: 0 24px 55px rgba(15,23,42,.18);
+  }
+  .games-hero-card .display-2 { color: #d8ff62; letter-spacing: -.08em; }
+  .games-hero-card h2 { color: #fff; }
+  .games-hero-card .btn { background: #d8ff62; border-color: #d8ff62; color: #111827; }
+  .games-hero-card .btn:hover { background: #c9ef59; border-color: #c9ef59; }
+  .game-card { transition: transform .15s ease, box-shadow .15s ease; }
+  .game-card:hover { transform: translateY(-3px); box-shadow: 0 16px 34px rgba(15,23,42,.10) !important; }
+  .coming-soon-card { background: repeating-linear-gradient(135deg,#fff 0,#fff 18px,#f8fafc 18px,#f8fafc 36px); }
+</style>
+
 <main class="container py-4 py-md-5">
   <div class="d-flex flex-column flex-lg-row align-items-lg-end justify-content-between gap-3 mb-4 mb-md-5">
     <div>
-      <div class="text-secondary small text-uppercase fw-semibold mb-2">icaijy.com</div>
+      <div class="text-secondary small text-uppercase fw-semibold mb-2">icaijy.com · extremely serious athletics department</div>
       <h1 class="display-5 fw-bold mb-2">67 Games</h1>
-      <p class="lead text-secondary mb-0">Pick a game and start a 20-second run.</p>
+      <p class="lead text-secondary mb-0">Pick a game and waste exactly 20 seconds with measurable precision.</p>
     </div>
-    <a class="btn btn-outline-dark" href="{% url 'brainrot:hall_of_fame' %}">
-      <i class="fa-solid fa-ranking-star me-1"></i> {% translate "Hall of Fame" %}
-    </a>
+    <a class="btn btn-outline-dark" href="{% url 'brainrot:hall_of_fame' %}"><i class="fa-solid fa-ranking-star me-1"></i> {% translate "Hall of Fame" %}</a>
   </div>
 
-  <div class="row g-3 g-lg-4">
-    <div class="col-12 col-md-6 col-xl-3">
-      <a class="card h-100 text-decoration-none text-body shadow-sm border-primary" href="{% url 'brainrot:counter' %}?mode=six_seven">
-        <div class="card-body p-4 d-flex flex-column">
-          <div class="d-flex align-items-start justify-content-between gap-3 mb-4">
-            <span class="badge text-bg-primary">20 s · camera</span>
-            <span class="display-6 fw-bold text-primary">67</span>
-          </div>
-          <h2 class="h3 fw-bold">{% translate "67 Counter" %}</h2>
-          <p class="text-secondary flex-grow-1 mb-4">{% translate "Move your arms up and down in the 6–7 pattern. Make as many counted moves as you can in 20 seconds." %}</p>
-          <span class="fw-semibold text-primary">{% translate "Begin" %} →</span>
+  <a class="card games-hero-card text-decoration-none mb-4" href="{% url 'brainrot:counter' %}?mode=six_seven">
+    <div class="card-body p-4 p-md-5">
+      <div class="row g-4 align-items-center">
+        <div class="col-12 col-lg-8">
+          <span class="badge rounded-pill text-bg-light mb-3">THE MAIN EVENT · 20 s · camera</span>
+          <h2 class="display-5 fw-bold mb-3">{% translate "67 Counter" %}</h2>
+          <p class="lead text-white-50 mb-4">{% translate "Move your arms up and down in the 6–7 pattern. Make as many counted moves as you can in 20 seconds." %}</p>
+          <span class="btn btn-light px-4">{% translate "Begin" %} →</span>
         </div>
-      </a>
+        <div class="col-12 col-lg-4 text-lg-end"><span class="display-2 fw-bold">67</span></div>
+      </div>
     </div>
+  </a>
 
-    <div class="col-12 col-md-6 col-xl-3">
-      <a class="card h-100 text-decoration-none text-body shadow-sm border-success" href="{% url 'brainrot:counter' %}?mode=leg_claps">
+  <div class="row g-3 g-lg-4">
+    <div class="col-12 col-lg-4">
+      <a class="card game-card h-100 text-decoration-none text-body shadow-sm border-success" href="{% url 'brainrot:counter' %}?mode=leg_claps">
         <div class="card-body p-4 d-flex flex-column">
-          <div class="d-flex align-items-start justify-content-between gap-3 mb-4">
-            <span class="badge text-bg-success">20 s · camera</span>
-            <span class="display-6 fw-bold text-success">TT</span>
-          </div>
+          <div class="d-flex align-items-start justify-content-between gap-3 mb-4"><span class="badge text-bg-success">20 s · camera</span><span class="display-6 fw-bold text-success">TT</span></div>
           <h2 class="h3 fw-bold mb-3">{% translate "Tung Tung Leg Claps" %}</h2>
           <p class="text-secondary flex-grow-1 mb-4">{% translate "Count each time Tung Tung's knees swing inward from a clearly open position. The knees must open again before another clap." %}</p>
           <span class="fw-semibold text-success">{% translate "Begin" %} →</span>
@@ -45,27 +58,21 @@
       </a>
     </div>
 
-    <div class="col-12 col-md-6 col-xl-3">
-      <a class="card h-100 text-decoration-none text-body shadow-sm border-danger" href="{% url 'brainrot:voice_counter' %}">
+    <div class="col-12 col-lg-4">
+      <a class="card game-card coming-soon-card h-100 text-decoration-none text-body shadow-sm" href="{% url 'brainrot:voice_counter' %}">
         <div class="card-body p-4 d-flex flex-column">
-          <div class="d-flex align-items-start justify-content-between gap-3 mb-4">
-            <span class="badge text-bg-danger">20 s · voice</span>
-            <span class="display-6 fw-bold text-danger">🗣️</span>
-          </div>
-          <h2 class="h3 fw-bold">{% translate "Six Seven Voice Speedrun" %}</h2>
-          <p class="text-secondary flex-grow-1 mb-4">{% translate "Say “six seven” as many times as possible. Only complete recognised pairs count, so speed without clear speech gets punished." %}</p>
-          <span class="fw-semibold text-danger">{% translate "Speak" %} →</span>
+          <div class="d-flex align-items-start justify-content-between gap-3 mb-4"><span class="badge text-bg-warning">COMING SOON</span><span class="display-6 fw-bold">🗣️</span></div>
+          <h2 class="h3 fw-bold">{% if CURRENT_LANGUAGE == 'zh-hans' %}语音 67 极速挑战{% else %}Six Seven Voice Speedrun{% endif %}</h2>
+          <p class="text-secondary flex-grow-1 mb-4">{% if CURRENT_LANGUAGE == 'zh-hans' %}连续高速说 six seven 的专用检测器还在重做。现有通用语音模型跟不上嘴速，所以先不上线半成品。{% else %}The fast continuous-speech detector is being rebuilt. Existing general speech models could not keep up, so the half-working version is parked for now.{% endif %}</p>
+          <span class="fw-semibold text-secondary">{% if CURRENT_LANGUAGE == 'zh-hans' %}看看施工现场{% else %}See what's being built{% endif %} →</span>
         </div>
       </a>
     </div>
 
-    <div class="col-12 col-md-6 col-xl-3">
-      <a class="card h-100 text-decoration-none text-body shadow-sm border-secondary" href="{% url 'brainrot:typing_test' %}">
+    <div class="col-12 col-lg-4">
+      <a class="card game-card h-100 text-decoration-none text-body shadow-sm border-secondary" href="{% url 'brainrot:typing_test' %}">
         <div class="card-body p-4 d-flex flex-column">
-          <div class="d-flex align-items-start justify-content-between gap-3 mb-4">
-            <span class="badge text-bg-secondary">keyboard</span>
-            <span class="display-6 fw-bold text-secondary">61</span>
-          </div>
+          <div class="d-flex align-items-start justify-content-between gap-3 mb-4"><span class="badge text-bg-secondary">keyboard</span><span class="display-6 fw-bold text-secondary">61</span></div>
           <h2 class="h3 fw-bold">{% translate "61 / 67 Typing Test" %}</h2>
           <p class="text-secondary flex-grow-1 mb-4">Type 61 and 67 as quickly and accurately as you can.</p>
           <span class="fw-semibold text-secondary">{% translate "Type" %} →</span>

--- a/brainrot/templates/brainrot/my_hall_of_fame.html
+++ b/brainrot/templates/brainrot/my_hall_of_fame.html
@@ -7,7 +7,7 @@
 <main class="container py-4 py-md-5">
   <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-4">
     <a class="btn btn-sm btn-outline-secondary" href="{% url 'brainrot:hall_of_fame' %}">← {% translate "Public Hall of Fame" %}</a>
-    <a class="btn btn-sm btn-primary" href="{% url 'brainrot:counter' %}">{% translate "New run" %}</a>
+    <a class="btn btn-sm btn-primary" href="{% url 'brainrot:counter' %}?mode=six_seven">{% translate "New run" %}</a>
   </div>
 
   <div class="mb-4">
@@ -29,14 +29,14 @@
         <div class="row g-3 align-items-center">
           <div class="col-auto"><span class="badge text-bg-light border text-dark">#{{ entry.id }}</span></div>
           <div class="col">
-            <h2 class="h5 border-0 ps-0 ms-0 mb-1">{% if superuser_mode %}{{ entry.public_name }} · {% endif %}{{ entry.created_at|date:'j M Y · H:i' }}</h2>
+            <h2 class="h5 mb-1">{% if superuser_mode %}{{ entry.public_name }} · {% endif %}{{ entry.created_at|date:'j M Y · H:i' }}</h2>
             <div class="text-secondary small">{{ entry.get_game_mode_display }} · {{ entry.get_visibility_display }} · {% blocktranslate with duration=entry.duration_seconds|floatformat:2 %}{{ duration }} seconds{% endblocktranslate %}</div>
           </div>
           <div class="col-auto"><span class="display-6 fw-bold">{{ entry.score }}</span></div>
         </div>
         <div class="d-flex flex-wrap gap-2 mt-3">
           <a class="btn btn-sm btn-outline-dark" href="{% url 'brainrot:hall_of_fame_detail' entry.id %}">{% translate "View" %}</a>
-          <a class="btn btn-sm btn-outline-secondary" href="{% url 'brainrot:hall_of_fame_video' entry.id %}?download=1">{% translate "Download" %}</a>
+          <a class="btn btn-sm btn-outline-secondary" href="{% url 'brainrot:hall_of_fame_video' entry.id %}?download=1&amp;format=mp4"><i class="fa-solid fa-download me-1"></i>{% translate "Download MP4" %}</a>
         </div>
         {% include 'brainrot/_entry_controls.html' %}
       </div>
@@ -44,9 +44,9 @@
     {% empty %}
     <div class="card">
       <div class="card-body p-4 text-center">
-        <h2 class="h4 border-0 ps-0 ms-0">{% translate "No owned specimens yet." %}</h2>
+        <h2 class="h4">{% translate "No owned specimens yet." %}</h2>
         <p class="text-secondary">{% translate "Anonymous submissions cannot be retroactively attached to this account." %}</p>
-        <a href="{% url 'brainrot:counter' %}" class="btn btn-primary">{% translate "Create an unnecessarily documented run" %}</a>
+        <a href="{% url 'brainrot:counter' %}?mode=six_seven" class="btn btn-primary">{% translate "Create an unnecessarily documented run" %}</a>
       </div>
     </div>
     {% endfor %}

--- a/brainrot/templates/brainrot/voice_coming_soon.html
+++ b/brainrot/templates/brainrot/voice_coming_soon.html
@@ -1,0 +1,87 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% get_current_language as CURRENT_LANGUAGE %}
+
+{% block title %}{% if CURRENT_LANGUAGE == 'zh-hans' %}语音 67 极速挑战 — 即将推出{% else %}Six Seven Voice Speedrun — Coming Soon{% endif %}{% endblock %}
+
+{% block content %}
+<style>
+  .voice-soon-page {
+    min-height: 72vh;
+    display: grid;
+    place-items: center;
+    padding: clamp(2.5rem, 7vw, 6rem) 1rem;
+    background:
+      radial-gradient(circle at 50% 8%, rgba(239,68,68,.14), transparent 24rem),
+      linear-gradient(180deg, #fff 0%, #f8fafc 100%);
+  }
+  .voice-soon-card {
+    width: min(820px, 100%);
+    padding: clamp(1.6rem, 5vw, 3.4rem);
+    border: 1px solid #e2e8f0;
+    border-radius: 2rem;
+    background: rgba(255,255,255,.96);
+    box-shadow: 0 30px 85px rgba(15,23,42,.12);
+  }
+  .voice-soon-mark {
+    display: grid;
+    place-items: center;
+    width: 76px;
+    height: 76px;
+    margin-bottom: 1.4rem;
+    border-radius: 1.35rem;
+    background: #111827;
+    font-size: 2.2rem;
+  }
+  .voice-soon-card h1 { font-size: clamp(2.2rem, 7vw, 4.6rem); font-weight: 950; letter-spacing: -.055em; }
+  .voice-soon-card .lead { color: #64748b; }
+  .voice-soon-note {
+    margin-top: 1.7rem;
+    padding: 1rem 1.1rem;
+    border: 1px solid #fed7aa;
+    border-radius: 1rem;
+    background: #fff7ed;
+    color: #9a3412;
+  }
+  .voice-build-grid { display: grid; grid-template-columns: repeat(3,1fr); gap: .8rem; margin-top: 1.5rem; }
+  .voice-build-grid div { padding: 1rem; border: 1px solid #e2e8f0; border-radius: 1rem; background: #f8fafc; }
+  .voice-build-grid strong { display: block; margin-bottom: .25rem; }
+  .voice-build-grid small { color: #64748b; line-height: 1.4; }
+  @media (max-width: 700px) { .voice-build-grid { grid-template-columns: 1fr; } }
+</style>
+
+<main class="voice-soon-page">
+  <section class="voice-soon-card">
+    <div class="voice-soon-mark">🗣️</div>
+    <span class="badge text-bg-warning mb-3">COMING SOON</span>
+
+    {% if CURRENT_LANGUAGE == 'zh-hans' %}
+      <h1>语音 67 极速挑战</h1>
+      <p class="lead">目标还是很简单：20 秒内尽可能多、尽可能清楚地连续说 <strong>six seven</strong>。</p>
+      <div class="voice-soon-note"><strong>现在先不上线半成品。</strong> 我们试过通用 ASR、唤醒词模型和现成单词分类器；慢速都能识别，但连续高速复读时漏判太严重。下一版会使用专门为这种玩法训练的小型本地模型。</div>
+      <div class="voice-build-grid">
+        <div><strong>⚡ 连续高速</strong><small>不等整句话结束，不要求每次 six seven 之间停顿。</small></div>
+        <div><strong>🧠 专用模型</strong><small>只需要理解 six、seven 和其他声音，不拿大模型打蚊子。</small></div>
+        <div><strong>🔒 本地运行</strong><small>最终目标仍是在浏览器本地计数，麦克风音频不送到语音识别服务器。</small></div>
+      </div>
+      <div class="d-flex flex-wrap gap-2 mt-4">
+        <a class="btn btn-dark" href="{% url 'brainrot:counter' %}?mode=six_seven">先玩 67 Counter →</a>
+        <a class="btn btn-outline-secondary" href="{% url 'brainrot:index' %}">返回所有 67 游戏</a>
+      </div>
+    {% else %}
+      <h1>Six Seven Voice Speedrun</h1>
+      <p class="lead">The goal is still simple: say <strong>six seven</strong> as many times as possible in 20 seconds while staying clear at ridiculous speed.</p>
+      <div class="voice-soon-note"><strong>The half-working prototype is parked.</strong> General ASR, wake-word spotting and an off-the-shelf word classifier all worked slowly but missed too many repetitions during continuous fast speech. The next version will use a tiny model trained specifically for this game.</div>
+      <div class="voice-build-grid">
+        <div><strong>⚡ Continuous speed</strong><small>No phrase-ending pause and no waiting for a long transcript to settle.</small></div>
+        <div><strong>🧠 Purpose-built model</strong><small>It only needs to understand six, seven and everything else.</small></div>
+        <div><strong>🔒 Local inference</strong><small>The target remains browser-local scoring without sending microphone audio to a speech-recognition service.</small></div>
+      </div>
+      <div class="d-flex flex-wrap gap-2 mt-4">
+        <a class="btn btn-dark" href="{% url 'brainrot:counter' %}?mode=six_seven">Play the working 67 Counter →</a>
+        <a class="btn btn-outline-secondary" href="{% url 'brainrot:index' %}">All 67 games</a>
+      </div>
+    {% endif %}
+  </section>
+</main>
+{% endblock %}

--- a/brainrot/test_downloads.py
+++ b/brainrot/test_downloads.py
@@ -1,0 +1,55 @@
+import io
+import tempfile
+from unittest.mock import patch
+
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase, override_settings
+
+from .models import HallOfFameEntry
+
+
+class HallOfFameMp4DownloadTests(TestCase):
+    def setUp(self):
+        self.private_directory = tempfile.TemporaryDirectory()
+        self.override = override_settings(PRIVATE_MEDIA_ROOT=self.private_directory.name)
+        self.override.enable()
+        self.entry = HallOfFameEntry.objects.create(
+            display_name='Phone Test',
+            score=67,
+            video=SimpleUploadedFile('phone.webm', b'legacy-test-bytes', content_type='video/webm'),
+            mime_type='video/webm',
+            duration_seconds=23,
+            visibility=HallOfFameEntry.Visibility.PUBLIC,
+        )
+        self.path = f'/67/hall-of-fame/{self.entry.id}/video/'
+
+    def tearDown(self):
+        self.override.disable()
+        self.private_directory.cleanup()
+
+    def test_legacy_download_url_still_streams_original_file(self):
+        response = self.client.get(f'{self.path}?download=1')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'video/webm')
+        self.assertIn('.webm"', response['Content-Disposition'])
+
+    @patch('brainrot.download_views.open_compatible_mp4')
+    def test_explicit_mp4_download_returns_real_mp4_headers(self, transcode):
+        transcode.return_value = (io.BytesIO(b'fake-mp4-for-response-test'), 26)
+        response = self.client.get(f'{self.path}?download=1&format=mp4')
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response['Content-Type'], 'video/mp4')
+        self.assertEqual(response['Content-Length'], '26')
+        self.assertIn('.mp4"', response['Content-Disposition'])
+        self.assertEqual(response['Cache-Control'], 'private, no-store')
+        transcode.assert_called_once()
+
+    def test_public_pages_point_download_buttons_at_mp4_format(self):
+        leaderboard = self.client.get('/67/hall-of-fame/')
+        self.assertContains(leaderboard, f'{self.path}?download=1&amp;format=mp4')
+        self.assertContains(leaderboard, 'Download MP4')
+
+        detail = self.client.get(f'/67/hall-of-fame/{self.entry.id}/')
+        self.assertContains(detail, f'{self.path}?download=1&amp;format=mp4')
+        self.assertContains(detail, 'Download MP4')

--- a/brainrot/test_voice.py
+++ b/brainrot/test_voice.py
@@ -1,29 +1,26 @@
-from django.contrib.auth import get_user_model
 from django.test import TestCase
 
 from .models import HallOfFameEntry
 
 
 class VoiceSpeedrunPageTests(TestCase):
-    def test_index_and_voice_page_expose_the_new_game(self):
+    def test_index_and_voice_page_expose_coming_soon_mode(self):
         index = self.client.get('/67/')
         self.assertEqual(index.status_code, 200)
         self.assertContains(index, '/67/voice/')
         self.assertContains(index, 'Six Seven Voice Speedrun')
+        self.assertContains(index, 'COMING SOON')
 
         voice = self.client.get('/67/voice/')
         self.assertEqual(voice.status_code, 200)
-        self.assertContains(voice, 'id="voice-app"')
-        self.assertContains(voice, 'data-game-mode="voice_67"')
-        self.assertContains(voice, 'voice_counter.js')
-        self.assertContains(voice, 'Keyword detections')
-        self.assertContains(voice, 'camera + microphone')
-        self.assertContains(voice, 'Keyword detection runs locally in this browser')
-        self.assertContains(voice, 'wake-word style detection')
-        self.assertNotContains(voice, "browser vendor's speech service")
-        self.assertNotContains(voice, 'about 40 MB of model data')
+        self.assertContains(voice, 'Six Seven Voice Speedrun')
+        self.assertContains(voice, 'COMING SOON')
+        self.assertContains(voice, 'tiny model trained specifically for this game')
+        self.assertNotContains(voice, 'id="voice-app"')
+        self.assertNotContains(voice, 'voice_counter.js')
+        self.assertNotContains(voice, 'Enable camera + microphone')
 
-    def test_voice_is_a_real_hall_of_fame_mode(self):
+    def test_voice_is_still_a_real_hall_of_fame_mode_for_historical_runs(self):
         voice_entry = HallOfFameEntry.objects.create(
             display_name='Fast Mouth',
             game_mode=HallOfFameEntry.GameMode.VOICE_67,
@@ -51,9 +48,9 @@ class VoiceSpeedrunPageTests(TestCase):
         self.assertContains(response, 'Fast Mouth')
         self.assertContains(response, 'said “six seven” 12 times')
         self.assertNotContains(response, 'Arms Only')
-        self.assertContains(response, f'/67/voice/?rival={voice_entry.id}')
+        self.assertContains(response, f'/67/hall-of-fame/{voice_entry.id}/')
 
-    def test_generic_challenge_dispatches_voice_but_preserves_pose_runner(self):
+    def test_generic_challenge_parks_voice_but_preserves_pose_runner(self):
         voice_entry = HallOfFameEntry.objects.create(
             display_name='Voice Rival',
             game_mode=HallOfFameEntry.GameMode.VOICE_67,
@@ -76,29 +73,9 @@ class VoiceSpeedrunPageTests(TestCase):
         )
 
         voice_challenge = self.client.get(f'/67/challenge/{voice_entry.id}/')
-        self.assertRedirects(
-            voice_challenge,
-            f'/67/voice/?rival={voice_entry.id}',
-            fetch_redirect_response=False,
-        )
+        self.assertRedirects(voice_challenge, '/67/voice/', fetch_redirect_response=False)
 
         pose_challenge = self.client.get(f'/67/challenge/{pose_entry.id}/')
         self.assertEqual(pose_challenge.status_code, 200)
         self.assertContains(pose_challenge, 'id="counter-app"')
         self.assertContains(pose_challenge, 'Pose Rival')
-
-    def test_voice_challenge_rejects_non_voice_rival_parameter(self):
-        user = get_user_model().objects.create_user('pose-user')
-        pose_entry = HallOfFameEntry.objects.create(
-            user=user,
-            game_mode=HallOfFameEntry.GameMode.LEG_CLAPS,
-            score=4,
-            video='hall_of_fame/leg-rival.webm',
-            mime_type='video/webm',
-            duration_seconds=23.25,
-            event_timeline=[2.0, 4.0, 6.0, 8.0],
-            visibility=HallOfFameEntry.Visibility.PUBLIC,
-        )
-
-        response = self.client.get(f'/67/voice/?rival={pose_entry.id}')
-        self.assertEqual(response.status_code, 404)

--- a/brainrot/test_voice.py
+++ b/brainrot/test_voice.py
@@ -20,6 +20,13 @@ class VoiceSpeedrunPageTests(TestCase):
         self.assertNotContains(voice, 'voice_counter.js')
         self.assertNotContains(voice, 'Enable camera + microphone')
 
+    def test_voice_coming_soon_has_direct_chinese_copy(self):
+        response = self.client.get('/67/voice/', HTTP_ACCEPT_LANGUAGE='zh-hans')
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, '语音 67 极速挑战')
+        self.assertContains(response, '专门为这种玩法训练的小型本地模型')
+        self.assertContains(response, '先玩 67 Counter')
+
     def test_voice_is_still_a_real_hall_of_fame_mode_for_historical_runs(self):
         voice_entry = HallOfFameEntry.objects.create(
             display_name='Fast Mouth',

--- a/brainrot/urls.py
+++ b/brainrot/urls.py
@@ -2,7 +2,7 @@ from django.urls import path
 from django.views.generic import RedirectView
 from django.views.i18n import JavaScriptCatalog
 
-from . import views, voice_views
+from . import download_views, views, voice_views
 
 app_name = 'brainrot'
 
@@ -16,7 +16,7 @@ urlpatterns = [
     path('hall-of-fame/', views.hall_of_fame, name='hall_of_fame'),
     path('hall-of-fame/mine/', views.my_hall_of_fame, name='my_hall_of_fame'),
     path('hall-of-fame/<int:entry_id>/', views.hall_of_fame_detail, name='hall_of_fame_detail'),
-    path('hall-of-fame/<int:entry_id>/video/', views.hall_of_fame_video, name='hall_of_fame_video'),
+    path('hall-of-fame/<int:entry_id>/video/', download_views.hall_of_fame_video, name='hall_of_fame_video'),
     path('hall-of-fame/<int:entry_id>/visibility/', views.set_hall_of_fame_visibility, name='set_hall_of_fame_visibility'),
     path('hall-of-fame/<int:entry_id>/delete/', views.delete_hall_of_fame_entry, name='delete_hall_of_fame_entry'),
     path('challenge/<int:entry_id>/', voice_views.challenge_dispatch, name='challenge'),

--- a/brainrot/video_downloads.py
+++ b/brainrot/video_downloads.py
@@ -1,0 +1,97 @@
+import os
+import shutil
+import subprocess
+import tempfile
+
+from django.conf import settings
+
+
+class Mp4TranscodeError(RuntimeError):
+    pass
+
+
+def open_compatible_mp4(entry):
+    """Return (open file handle, size) for a short, broadly playable MP4.
+
+    HOF recordings may be stored as WebM because that is what MediaRecorder
+    produced on the submitting browser. Downloads are normalised server-side so
+    Safari/iPhone users do not need WebCodecs or a client-side transcoder.
+
+    The temporary file is unlinked immediately after opening on the Linux
+    production host; FileResponse keeps the descriptor alive until streaming
+    finishes, so the conversion does not build a permanent second video archive.
+    """
+    ffmpeg = shutil.which('ffmpeg')
+    if not ffmpeg:
+        raise Mp4TranscodeError('MP4 download is temporarily unavailable (ffmpeg missing).')
+
+    try:
+        source_path = entry.video.path
+    except (NotImplementedError, AttributeError) as exc:
+        raise Mp4TranscodeError('The recording storage cannot be transcoded on this server.') from exc
+
+    os.makedirs(settings.PRIVATE_MEDIA_ROOT, exist_ok=True)
+    temporary = tempfile.NamedTemporaryFile(
+        suffix='.mp4',
+        prefix=f'hof-{entry.pk}-',
+        dir=settings.PRIVATE_MEDIA_ROOT,
+        delete=False,
+    )
+    output_path = temporary.name
+    temporary.close()
+
+    command = [
+        ffmpeg,
+        '-hide_banner',
+        '-loglevel', 'error',
+        '-y',
+        '-i', source_path,
+        '-map', '0:v:0',
+        '-map', '0:a:0?',
+        '-sn',
+        '-vf', 'scale=trunc(iw/2)*2:trunc(ih/2)*2',
+        '-c:v', 'libx264',
+        '-preset', 'veryfast',
+        '-crf', '23',
+        '-profile:v', 'baseline',
+        '-level', '3.1',
+        '-pix_fmt', 'yuv420p',
+        '-c:a', 'aac',
+        '-b:a', '128k',
+        '-movflags', '+faststart',
+        '-map_metadata', '-1',
+        output_path,
+    ]
+
+    try:
+        completed = subprocess.run(
+            command,
+            capture_output=True,
+            text=True,
+            timeout=45,
+            check=False,
+        )
+        if completed.returncode != 0 or not os.path.exists(output_path) or os.path.getsize(output_path) <= 0:
+            detail = (completed.stderr or '').strip().splitlines()
+            detail = detail[-1] if detail else 'ffmpeg did not produce an MP4 file'
+            raise Mp4TranscodeError(f'Could not prepare the MP4 download: {detail}')
+
+        size = os.path.getsize(output_path)
+        handle = open(output_path, 'rb')
+        # Production runs on Linux. An unlinked open file remains readable by
+        # FileResponse but disappears automatically when the descriptor closes.
+        try:
+            os.unlink(output_path)
+        except OSError:
+            # Harmless fallback for non-POSIX development environments.
+            pass
+        return handle, size
+    except subprocess.TimeoutExpired as exc:
+        raise Mp4TranscodeError('Preparing the MP4 download took too long.') from exc
+    except Exception:
+        if os.path.exists(output_path):
+            try:
+                os.unlink(output_path)
+            except OSError:
+                pass
+        raise

--- a/brainrot/voice_views.py
+++ b/brainrot/voice_views.py
@@ -1,42 +1,12 @@
-from django.conf import settings
 from django.shortcuts import get_object_or_404, redirect, render
 from django.urls import reverse
-from django.views.decorators.csrf import ensure_csrf_cookie
 
 from .models import HallOfFameEntry
 
 
-@ensure_csrf_cookie
 def voice_counter(request):
-    rival = None
-    rival_id = request.GET.get('rival')
-    if rival_id:
-        rival = get_object_or_404(
-            HallOfFameEntry.objects.select_related('user'),
-            pk=rival_id,
-            game_mode=HallOfFameEntry.GameMode.VOICE_67,
-            visibility=HallOfFameEntry.Visibility.PUBLIC,
-        )
-
-    context = {
-        'turnstile_enabled': settings.TURNSTILE_ENABLED,
-        'turnstile_site_key': settings.TURNSTILE_SITE_KEY,
-        'max_upload_mb': settings.HOF_MAX_UPLOAD_BYTES // (1024 * 1024),
-        'anonymous_submission_available': settings.TURNSTILE_ENABLED or settings.DEBUG,
-        'rival': rival,
-        'game_mode': HallOfFameEntry.GameMode.VOICE_67,
-    }
-    if rival is not None:
-        timeline = rival.event_timeline
-        timeline_exact = len(timeline) == rival.score
-        if not timeline_exact and rival.score:
-            timeline = [round((index + 1) * 20 / (rival.score + 1), 3) for index in range(rival.score)]
-        context.update({
-            'rival_timeline': timeline,
-            'rival_timeline_exact': timeline_exact,
-        })
-
-    return render(request, 'brainrot/voice_counter.html', context)
+    """Public placeholder while the fast continuous-speech detector is rebuilt."""
+    return render(request, 'brainrot/voice_coming_soon.html')
 
 
 def challenge_dispatch(request, entry_id):
@@ -46,7 +16,9 @@ def challenge_dispatch(request, entry_id):
         visibility=HallOfFameEntry.Visibility.PUBLIC,
     )
     if rival.game_mode == HallOfFameEntry.GameMode.VOICE_67:
-        return redirect(f"{reverse('brainrot:voice_counter')}?rival={rival.pk}")
+        # Historical Voice HOF links remain valid, but new voice runs are
+        # intentionally unavailable until the purpose-built detector ships.
+        return redirect(reverse('brainrot:voice_counter'))
 
     # Keep the mature pose challenge path exactly as-is for the two camera modes.
     from . import views

--- a/homepage/templates/homepage/index.html
+++ b/homepage/templates/homepage/index.html
@@ -5,179 +5,128 @@
 
 {% block content %}
 <style>
-    /* 样式隔离，确保不污染全局 */
-    #homepage-wrapper {
-        font-family: 'Inter', -apple-system, system-ui, sans-serif;
-        -webkit-font-smoothing: antialiased;
-        color: #1e293b;
-        padding: 60px 20px;
-        min-height: 80vh;
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        background: #ffffff; /* 纯白背景 */
-    }
-
-    #homepage-wrapper .hero-section {
-        max-width: 800px;
-        text-align: center;
-        margin-bottom: 50px;
-    }
-
-    #homepage-wrapper h1 {
-        font-size: 3.5rem;
-        font-weight: 800;
-        letter-spacing: -0.02em;
-        margin-bottom: 20px;
-        background: linear-gradient(135deg, #0ea5e9 0%, #6366f1 100%);
-        -webkit-background-clip: text;
-        -webkit-text-fill-color: transparent;
-    }
-
-    #homepage-wrapper .lead {
-        font-size: 1.25rem;
-        color: #64748b;
-        margin-bottom: 30px;
-    }
-
-    /* 快捷链接美化 */
-    #homepage-wrapper .quick-links {
-        font-size: 1.1rem;
-        color: #94a3b8;
-        border-top: 1px solid #f1f5f9;
-        padding-top: 25px;
-    }
-
-    #homepage-wrapper .quick-links a {
-        color: #0ea5e9;
-        text-decoration: none;
-        font-weight: 600;
-        border-bottom: 2px solid transparent;
-        transition: all 0.2s;
-    }
-
-    #homepage-wrapper .quick-links a:hover {
-        border-bottom-color: #0ea5e9;
-    }
-
-    /* 按钮组卡片化 */
-    #homepage-wrapper .button-grid {
-        display: grid;
-        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-        gap: 20px;
-        width: 100%;
-        max-width: 900px;
-        margin-top: 40px;
-    }
-
-    #homepage-wrapper .featured-grid {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-        max-width: 900px;
-        margin-top: 10px;
-    }
-
-    #homepage-wrapper .featured-hof {
-        grid-column: 1 / -1;
-        min-height: 105px;
-        font-size: 1.35rem;
-    }
-
-    #homepage-wrapper .oi-section {
-        width: 100%;
-        max-width: 900px;
-        margin-top: 55px;
-        padding-top: 28px;
-        border-top: 1px solid #e2e8f0;
-    }
-
-    #homepage-wrapper .section-label {
-        color: #64748b;
-        font-size: .75rem;
-        font-weight: 800;
-        letter-spacing: .12em;
-        text-transform: uppercase;
-    }
-
-    #homepage-wrapper .oi-section .button-grid { margin-top: 16px; }
-
-    #homepage-wrapper .nav-card {
-        padding: 24px;
-        border-radius: 16px;
-        text-decoration: none;
-        text-align: center;
-        font-weight: 700;
-        font-size: 1.1rem;
-        transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        border: 1px solid rgba(0,0,0,0.05);
-        box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.05);
-    }
-
-    #homepage-wrapper .nav-card:hover {
-        transform: translateY(-5px);
-        box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1);
-    }
-
-    /* 针对不同按钮的配色优化 */
-    .btn-blog { background: #eff6ff; color: #1d4ed8; border-color: #dbeafe; }
-    .btn-leader { background: #f0fdf4; color: #15803d; border-color: #dcfce7; }
-    .btn-oj { background: #fffbeb; color: #b45309; border-color: #fef3c7; }
-    .btn-analytics { background: #faf5ff; color: #7e22ce; border-color: #f3e8ff; }
-    .btn-brainrot { background: #fff7ed; color: #c2410c; border-color: #fed7aa; }
-    .btn-hof { background: #111827; color: #d8ff62; border-color: #111827; }
-    .btn-hof:hover { color: #d8ff62; }
-
-    @media (max-width: 600px) {
-        #homepage-wrapper h1 { font-size: 2.5rem; }
-        #homepage-wrapper .button-grid, #homepage-wrapper .featured-grid { grid-template-columns: 1fr; }
-        #homepage-wrapper .featured-hof { grid-column: auto; }
-    }
+  #homepage-wrapper {
+    min-height: 78vh;
+    padding: clamp(2.5rem, 6vw, 5.5rem) 1rem 3.5rem;
+    background:
+      radial-gradient(circle at 16% 8%, rgba(216,255,98,.26), transparent 28rem),
+      radial-gradient(circle at 86% 12%, rgba(59,130,246,.13), transparent 26rem),
+      #f8fafc;
+  }
+  #homepage-wrapper .home-shell { width: min(1080px, 100%); margin: 0 auto; }
+  #homepage-wrapper .hero {
+    display: grid;
+    grid-template-columns: minmax(0, 1.2fr) minmax(250px, .8fr);
+    gap: clamp(2rem, 5vw, 4.5rem);
+    align-items: center;
+    padding: clamp(1.5rem, 4vw, 3rem);
+    overflow: hidden;
+    border: 1px solid #dbe4ee;
+    border-radius: 2rem;
+    background: rgba(255,255,255,.88);
+    box-shadow: 0 28px 80px rgba(15,23,42,.10);
+  }
+  #homepage-wrapper .eyebrow {
+    display: inline-flex;
+    align-items: center;
+    gap: .5rem;
+    margin-bottom: 1rem;
+    color: #64748b;
+    font-size: .76rem;
+    font-weight: 850;
+    letter-spacing: .12em;
+    text-transform: uppercase;
+  }
+  #homepage-wrapper .live-dot {
+    width: .55rem; height: .55rem; border-radius: 999px; background: #84cc16;
+    box-shadow: 0 0 0 .3rem rgba(132,204,22,.13);
+  }
+  #homepage-wrapper h1 {
+    margin: 0 0 1rem;
+    font-size: clamp(2.6rem, 7vw, 5.7rem);
+    font-weight: 950;
+    line-height: .94;
+    letter-spacing: -.065em;
+  }
+  #homepage-wrapper h1 span { color: #2563eb; }
+  #homepage-wrapper .hero-copy { max-width: 650px; color: #64748b; font-size: clamp(1rem, 2vw, 1.25rem); }
+  #homepage-wrapper .hero-actions { display: flex; flex-wrap: wrap; gap: .75rem; margin-top: 1.6rem; }
+  #homepage-wrapper .play-67 {
+    display: inline-flex; align-items: center; gap: .65rem;
+    padding: .85rem 1.15rem; border-radius: .9rem;
+    background: #0f172a; color: #d8ff62; text-decoration: none; font-weight: 850;
+    box-shadow: 0 14px 32px rgba(15,23,42,.2);
+  }
+  #homepage-wrapper .play-67:hover { color: #fff; transform: translateY(-1px); }
+  #homepage-wrapper .secondary-action {
+    display: inline-flex; align-items: center; gap: .5rem;
+    padding: .85rem 1.05rem; border: 1px solid #cbd5e1; border-radius: .9rem;
+    background: #fff; color: #334155; text-decoration: none; font-weight: 750;
+  }
+  #homepage-wrapper .hero-mark {
+    position: relative; display: grid; place-items: center; aspect-ratio: 1;
+    border-radius: 2rem; background: #0b1220; color: #d8ff62;
+    font-size: clamp(6rem, 13vw, 10rem); font-weight: 950; letter-spacing: -.1em;
+    box-shadow: inset 0 0 0 1px rgba(255,255,255,.09), 0 24px 70px rgba(15,23,42,.22);
+  }
+  #homepage-wrapper .hero-mark small {
+    position: absolute; bottom: 1.1rem; left: 1.2rem; right: 1.2rem;
+    color: #94a3b8; font-size: .72rem; font-weight: 800; letter-spacing: .1em; text-align: center;
+  }
+  #homepage-wrapper .section-head { margin: 3.2rem 0 1rem; }
+  #homepage-wrapper .section-head h2 { margin: 0; font-size: 1.35rem; font-weight: 850; }
+  #homepage-wrapper .section-head p { margin: .35rem 0 0; color: #64748b; }
+  #homepage-wrapper .home-grid { display: grid; grid-template-columns: repeat(4, 1fr); gap: 1rem; }
+  #homepage-wrapper .home-card {
+    min-height: 150px; padding: 1.2rem; border: 1px solid #e2e8f0; border-radius: 1.15rem;
+    background: #fff; color: #0f172a; text-decoration: none; box-shadow: 0 7px 20px rgba(15,23,42,.04);
+    transition: transform .16s ease, box-shadow .16s ease, border-color .16s ease;
+  }
+  #homepage-wrapper .home-card:hover { transform: translateY(-3px); border-color: #cbd5e1; box-shadow: 0 16px 32px rgba(15,23,42,.08); }
+  #homepage-wrapper .home-card i { color: #2563eb; font-size: 1.35rem; }
+  #homepage-wrapper .home-card strong { display: block; margin-top: 1.4rem; font-size: 1.02rem; }
+  #homepage-wrapper .home-card small { display: block; margin-top: .35rem; color: #64748b; line-height: 1.45; }
+  @media (max-width: 900px) {
+    #homepage-wrapper .hero { grid-template-columns: 1fr; }
+    #homepage-wrapper .hero-mark { max-width: 330px; width: 100%; margin: 0 auto; }
+    #homepage-wrapper .home-grid { grid-template-columns: repeat(2, 1fr); }
+  }
+  @media (max-width: 560px) {
+    #homepage-wrapper { padding-inline: .7rem; }
+    #homepage-wrapper .hero { border-radius: 1.35rem; }
+    #homepage-wrapper .home-grid { grid-template-columns: 1fr; }
+  }
 </style>
 
 <div id="homepage-wrapper">
-    <div class="hero-section">
-        <h1>{% trans "Welcome to My Homepage" %}</h1>
-        <p class="lead">{% trans "Projects, questionable experiments, and an archive of competitive-programming history." %}</p>
-
-        <div class="quick-links">
-            <p>
-                {% trans "Check out my" %}
-                <a href="/blog">{% trans "blog" %}</a>,
-                <a href="{% url 'brainrot:hall_of_fame' %}">67 Hall of Fame</a>,
-                {% trans "or" %}
-                <a href="{% url 'brainrot:index' %}">61/67 Research Division</a>.
-            </p>
+  <div class="home-shell">
+    <section class="hero">
+      <div>
+        <div class="eyebrow"><span class="live-dot"></span> currently the important bit</div>
+        <h1>Play the <span>67 Counter.</span></h1>
+        <p class="hero-copy">{% trans "Projects, questionable experiments, and an archive of competitive-programming history." %} The 20-second 67 game is currently receiving a suspicious amount of real-world use.</p>
+        <div class="hero-actions">
+          <a class="play-67" href="{% url 'brainrot:counter' %}?mode=six_seven"><i class="fa-solid fa-play"></i> Play 67 now</a>
+          <a class="secondary-action" href="{% url 'brainrot:hall_of_fame' %}"><i class="fa-solid fa-ranking-star"></i> Hall of Fame</a>
+          <a class="secondary-action" href="{% url 'brainrot:index' %}"><i class="fa-solid fa-gamepad"></i> All 67 games</a>
         </div>
-    </div>
-
-    <div class="button-grid featured-grid">
-        <a href="{% url 'brainrot:hall_of_fame' %}" class="nav-card btn-hof featured-hof">
-            ★ 67 Hall of Fame — 20-second video leaderboard
-        </a>
-        <a href="{% url 'brainrot:index' %}" class="nav-card btn-brainrot">
-            🧪 61/67 Research Division
-        </a>
-        <a href="/blog" class="nav-card btn-blog">
-            ✍️ {% trans "Henry's Blog" %}
-        </a>
-    </div>
-
-    <section class="oi-section">
-      <span class="section-label">OI / competitive programming archive</span>
-      <div class="button-grid">
-        <a href="/orac-leaderboards" class="nav-card btn-leader">
-            🏆 ORAC Leaderboards++
-        </a>
-        <a href="/oracdata" class="nav-card btn-analytics">
-            📊 {% trans "ORAC2 Analytics" %}
-        </a>
-        <a href="/oj" class="nav-card btn-oj">
-            🪦 {% trans "Speed Online Judge" %} (retired)
-        </a>
       </div>
+      <a class="hero-mark text-decoration-none" href="{% url 'brainrot:counter' %}?mode=six_seven" aria-label="Open 67 Counter">
+        67
+        <small>20 SECOND HUMAN PERFORMANCE PROTOCOL</small>
+      </a>
     </section>
+
+    <div class="section-head">
+      <h2>Everything else</h2>
+      <p>The serious projects are still here. They have simply lost the homepage election.</p>
+    </div>
+    <div class="home-grid">
+      <a class="home-card" href="/blog"><i class="fa-solid fa-pen-nib"></i><strong>{% trans "Henry's Blog" %}</strong><small>Notes, articles and assorted write-ups.</small></a>
+      <a class="home-card" href="/orac-leaderboards"><i class="fa-solid fa-ranking-star"></i><strong>ORAC Leaderboards++</strong><small>Competitive-programming leaderboard archive.</small></a>
+      <a class="home-card" href="/oracdata"><i class="fa-solid fa-chart-line"></i><strong>{% trans "ORAC2 Analytics" %}</strong><small>Historical data and statistics.</small></a>
+      <a class="home-card" href="{% url 'brainrot:index' %}"><i class="fa-solid fa-flask"></i><strong>67 Research Division</strong><small>67, Tung Tung, typing, and whatever terrible idea ships next.</small></a>
+    </div>
+  </div>
 </div>
 {% endblock %}

--- a/orac_tracker/templates/leaderboard/index.html
+++ b/orac_tracker/templates/leaderboard/index.html
@@ -5,7 +5,7 @@
 {% block title %}{% trans "ORAC Leaderboards - Henry's Website" %}{% endblock %}
 
 {% block content %}
-<style>.maincontent{font-family:"Droid Serif"}.maincontent h1{font-family:"Arial";font-weight:bold}.maincontent h2.no-indent{padding-left:none;border-left:none}.badge{font-size:100%;vertical-align:middle}h1{text-align:center}.hub-badge{width:60px}.sub-badge{width:40px}.x-card-body-sets{padding-top:0;padding-bottom:0}.leaderboard-grid{padding:0;margin:0;width:100%;display:grid;list-style:none;grid-auto-flow:column;grid-template-columns:repeat(auto-fit,minmax(0,1fr));grid-gap:15px;grid-template-rows:repeat(10,1fr)}@media screen and (max-width:900px){.leaderboard-grid{grid-template-rows:repeat(30,minmax(0,1fr))!important}}.leaderboard-grid h3{align-items:center;justify-content:center;display:flex;margin:0}.leaderboard-grid li{white-space:nowrap;border-radius:5px;padding:.5rem;box-shadow:0 0 0 1px black inset;vertical-align:middle;display:flex;max-width:500px;margin:0 auto;width:100%}.leaderboard-grid li .place{width:50px;border-right:1px solid black;margin-right:5px;flex-shrink:0}.leaderboard-grid li .username-field{flex-grow:1}.leaderboard-grid li .solvecount{width:50px;border-left:1px solid black;margin-left:5px;text-align:right;flex-shrink:0}</style>
+<style>.maincontent{font-family:Inter,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif}.badge{font-size:100%;vertical-align:middle}h1{text-align:center}.hub-badge{width:60px}.sub-badge{width:40px}.x-card-body-sets{padding-top:0;padding-bottom:0}.leaderboard-grid{padding:0;margin:0;width:100%;display:grid;list-style:none;grid-auto-flow:column;grid-template-columns:repeat(auto-fit,minmax(0,1fr));grid-gap:15px;grid-template-rows:repeat(10,1fr)}@media screen and (max-width:900px){.leaderboard-grid{grid-template-rows:repeat(30,minmax(0,1fr))!important}}.leaderboard-grid h3{align-items:center;justify-content:center;display:flex;margin:0}.leaderboard-grid li{white-space:nowrap;border-radius:8px;padding:.5rem;box-shadow:0 0 0 1px #cbd5e1 inset;vertical-align:middle;display:flex;max-width:500px;margin:0 auto;width:100%;background:#fff}.leaderboard-grid li .place{width:50px;border-right:1px solid #cbd5e1;margin-right:5px;flex-shrink:0}.leaderboard-grid li .username-field{flex-grow:1}.leaderboard-grid li .solvecount{width:50px;border-left:1px solid #cbd5e1;margin-left:5px;text-align:right;flex-shrink:0}</style>
 
 <div class="container-xl mt-5">
     <h1>ORAC Leaderboards</h1>
@@ -18,16 +18,14 @@
     </p>
     <p>Last updated: <span id="last-updated">{{ last_updated }}</span></p>
 
-    <!-- Tabs -->
-    <ul class="nav nav-tabs" id="leaderboard-tabs">
-        <li class="nav-item"><a class="nav-link active" data-toggle="tab" href="#overall">Overall</a></li>
-        <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#week">Week</a></li>
-        <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#month">Month</a></li>
-        <li class="nav-item"><a class="nav-link" data-toggle="tab" href="#year">Year</a></li>
+    <ul class="nav nav-tabs" id="leaderboard-tabs" role="tablist">
+        <li class="nav-item" role="presentation"><a class="nav-link active" data-bs-toggle="tab" href="#overall" role="tab">Overall</a></li>
+        <li class="nav-item" role="presentation"><a class="nav-link" data-bs-toggle="tab" href="#week" role="tab">Week</a></li>
+        <li class="nav-item" role="presentation"><a class="nav-link" data-bs-toggle="tab" href="#month" role="tab">Month</a></li>
+        <li class="nav-item" role="presentation"><a class="nav-link" data-bs-toggle="tab" href="#year" role="tab">Year</a></li>
     </ul>
     <div class="tab-content mt-3">
-        <!-- Overall Tab -->
-        <div class="tab-pane fade show active" id="overall">
+        <div class="tab-pane fade show active" id="overall" role="tabpanel">
             <ul class="leaderboard-grid">
                 {% for user, data in people.overall.items %}
                     <li>
@@ -38,9 +36,7 @@
                 {% endfor %}
             </ul>
         </div>
-
-        <!-- Week Tab -->
-        <div class="tab-pane fade" id="week">
+        <div class="tab-pane fade" id="week" role="tabpanel">
             <ul class="leaderboard-grid list-unstyled">
                 {% for user, data in people.recent.week.items %}
                     <li>
@@ -51,9 +47,7 @@
                 {% endfor %}
             </ul>
         </div>
-
-        <!-- Month Tab -->
-        <div class="tab-pane fade" id="month">
+        <div class="tab-pane fade" id="month" role="tabpanel">
             <ul class="leaderboard-grid list-unstyled">
                 {% for user, data in people.recent.month.items %}
                     <li>
@@ -64,9 +58,7 @@
                 {% endfor %}
             </ul>
         </div>
-
-        <!-- Year Tab -->
-        <div class="tab-pane fade" id="year">
+        <div class="tab-pane fade" id="year" role="tabpanel">
             <ul class="leaderboard-grid list-unstyled">
                 {% for user, data in people.recent.year.items %}
                     <li>

--- a/static/global.css
+++ b/static/global.css
@@ -1,17 +1,203 @@
+:root {
+    --site-ink: #0f172a;
+    --site-muted: #64748b;
+    --site-border: #e2e8f0;
+    --site-surface: #ffffff;
+    --site-bg: #f8fafc;
+    --site-nav: #0b1220;
+    --site-accent: #d8ff62;
+}
+
 html, body {
-    height: 100%;
+    min-height: 100%;
     margin: 0;
+}
+
+body {
+    min-height: 100vh;
     display: flex;
     flex-direction: column;
+    background: var(--site-bg);
+    color: var(--site-ink);
+}
+
+.maincontent {
+    font-family: Inter, ui-sans-serif, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+    -webkit-font-smoothing: antialiased;
+}
+
+.maincontent h1,
+.maincontent h2,
+.maincontent h3,
+.maincontent h4,
+.maincontent h5,
+.maincontent h6 {
+    color: var(--site-ink);
+    font-family: inherit;
+    letter-spacing: -0.018em;
+}
+
+.maincontent h2 {
+    padding-left: 0;
+    border-left: 0;
+    margin-left: 0;
 }
 
 .content {
     flex: 1;
+    min-width: 0;
 }
 
-.title{
-    text-align:center;
+.site-navbar {
+    background: rgba(11, 18, 32, 0.96);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 10px 35px rgba(15, 23, 42, 0.12);
+    backdrop-filter: blur(16px);
+    -webkit-backdrop-filter: blur(16px);
+}
 
+.site-navbar .container-xl {
+    min-height: 66px;
+}
+
+.site-brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.65rem;
+    margin-right: 1rem;
+}
+
+.site-brand img {
+    flex: 0 0 auto;
+}
+
+.site-brand span {
+    display: flex;
+    flex-direction: column;
+    line-height: 1.05;
+}
+
+.site-brand strong {
+    color: #fff;
+    font-size: 1rem;
+    font-weight: 800;
+    letter-spacing: -0.02em;
+}
+
+.site-brand small {
+    margin-top: 0.18rem;
+    color: #94a3b8;
+    font-size: 0.68rem;
+    font-weight: 600;
+}
+
+.site-navbar .nav-link {
+    border-radius: 0.72rem;
+    color: #cbd5e1;
+    font-size: 0.93rem;
+    font-weight: 650;
+    padding: 0.58rem 0.72rem !important;
+    transition: background 120ms ease, color 120ms ease;
+}
+
+.site-navbar .nav-link:hover,
+.site-navbar .nav-link:focus {
+    background: rgba(255, 255, 255, 0.08);
+    color: #fff;
+}
+
+.site-67-shortcut {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+    min-width: 58px;
+    margin-right: 0.35rem;
+    padding: 0.46rem 0.72rem;
+    border: 1px solid rgba(216, 255, 98, 0.6);
+    border-radius: 999px;
+    background: var(--site-accent);
+    color: #111827;
+    font-weight: 950;
+    line-height: 1;
+    text-decoration: none;
+    box-shadow: 0 0 0 1px rgba(216, 255, 98, 0.08), 0 8px 24px rgba(216, 255, 98, 0.16);
+    transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.site-67-shortcut span {
+    font-size: 1.05rem;
+    letter-spacing: -0.04em;
+}
+
+.site-67-shortcut small {
+    font-size: 0.66rem;
+    font-weight: 850;
+    text-transform: uppercase;
+}
+
+.site-67-shortcut:hover,
+.site-67-shortcut:focus {
+    color: #111827;
+    transform: translateY(-1px);
+    box-shadow: 0 12px 30px rgba(216, 255, 98, 0.25);
+}
+
+.site-dropdown {
+    overflow: hidden;
+    padding: 0.4rem;
+    border: 1px solid var(--site-border);
+    border-radius: 0.9rem;
+    box-shadow: 0 18px 48px rgba(15, 23, 42, 0.14);
+}
+
+.site-dropdown .dropdown-item {
+    border-radius: 0.62rem;
+    padding: 0.58rem 0.7rem;
+}
+
+.card {
+    border-color: var(--site-border);
+    border-radius: 1rem;
+}
+
+.btn {
+    border-radius: 0.72rem;
+    font-weight: 650;
+}
+
+.form-control,
+.form-select {
+    border-radius: 0.72rem;
+}
+
+.site-footer {
+    margin-top: 3.5rem;
+    padding: 1.1rem 0;
+    border-top: 1px solid #1e293b;
+    background: #0b1220;
+    color: #94a3b8;
+    font-size: 0.86rem;
+}
+
+.site-footer-links {
+    display: inline-flex;
+    flex-wrap: wrap;
+    gap: 0.9rem;
+}
+
+.site-footer a {
+    color: #cbd5e1;
+    font-weight: 650;
+    text-decoration: none;
+}
+
+.site-footer a:hover {
+    color: var(--site-accent);
+}
+
+.title {
+    text-align: center;
 }
 
 .retired-page {
@@ -43,4 +229,18 @@ html, body {
     background: #fef3c7;
     font: 700 .75rem/1 system-ui, sans-serif;
     letter-spacing: .08em;
+}
+
+@media (max-width: 991.98px) {
+    .site-navbar .navbar-collapse {
+        padding: 0.7rem 0 0.5rem;
+    }
+
+    .site-navbar .navbar-nav {
+        gap: 0.15rem;
+    }
+
+    .site-navbar .dropdown-menu {
+        margin-bottom: 0.4rem;
+    }
 }

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,88 +1,79 @@
-{% load static %}
-{% load i18n %}
+{% load static i18n %}
 {% get_current_language as CURRENT_LANGUAGE %}
 <!DOCTYPE html>
 <html lang="{{ CURRENT_LANGUAGE }}">
   <head>
+    <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <style>
-      .maincontent {
-        font-family: 'Droid Serif';
-      }
-      .maincontent h1 {
-        font-family: 'Arial';
-        font-weight: bold;
-      }
-      .maincontent h2 {
-        font-family: 'Arial';
-        padding-left: 0.25rem;
-        border-left: 0.5rem solid #c2c1c1;
-        margin-left: -0.25rem;
-      }
-      .maincontent h2.no-indent {
-        padding-left: none;
-        border-left: none;
-        margin-left: 0;
-      }
-    </style>
-    <title>
-      {% block title %}
-        Henry's Website
-      {% endblock %}
-    </title>
+    <meta name="theme-color" content="#0b1220" />
+    <title>{% block title %}Henry's Website{% endblock %}</title>
+
     <link rel="icon" type="image/x-icon" href="{% static 'favicon.ico' %}" />
-    <script src="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.6.0/js/all.min.js"></script>
-    <link href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.6.0/css/fontawesome.min.css" rel="stylesheet" />
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.1.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-/bQdsTh/da6pkI1MST/rWKFNjaCP5gBSY4sEBT38Q/9RBh9AH40zEOg7Hlq2THRZ" crossorigin="anonymous"></script>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YctnYmDr5pNlyT2bRjXh0JMhjY6hW+ALEwIH" crossorigin="anonymous" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@fortawesome/fontawesome-free@6.6.0/css/all.min.css" />
+    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/styles/default.min.css" />
     <link rel="stylesheet" type="text/css" href="{% static 'global.css' %}" />
     <link rel="stylesheet" type="text/css" href="{% static 'monokai.css' %}" />
-    <script src="https://code.jquery.com/jquery-3.4.1.slim.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/popper.js@1.16.0/dist/umd/popper.min.js"></script>
-    <script src="https://stackpath.bootstrapcdn.com/bootstrap/4.4.1/js/bootstrap.min.js"></script>
-    <style>
-      @import url('https://fonts.googleapis.com/css?family=Droid+Serif');
-    </style>
-    <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/styles/default.min.css" />
-    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/highlight.min.js"></script>
-
-    <script>
-      hljs.highlightAll()
-    </script>
+    {% block extra_head %}{% endblock %}
   </head>
 
   <body class="maincontent">
-    <nav class="navbar navbar-expand-lg navbar-dark bg-dark">
-      <div class="container">
-        <a class="navbar-brand" href="{% url 'home' %}"><img src="{% static 'compass.svg' %}" height="50" /> {% trans 'Henry - Home' %}</a>
-        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
-        <div class="collapse navbar-collapse" id="navbarNav">
-          <ul class="navbar-nav me-auto">
-            <li class="nav-item">
-              <a class="nav-link" href="{% url 'blog' %}"><i class="fa-solid fa-blog"></i> {% trans 'Blog' %}</a>
+    <nav class="navbar navbar-expand-lg navbar-dark site-navbar sticky-top" aria-label="Primary navigation">
+      <div class="container-xl">
+        <a class="navbar-brand site-brand" href="{% url 'home' %}" aria-label="icaijy.com home">
+          <img src="{% static 'compass.svg' %}" width="34" height="34" alt="" />
+          <span>
+            <strong>icaijy.com</strong>
+            <small>{% trans "Henry's Website" %}</small>
+          </span>
+        </a>
+
+        <a class="site-67-shortcut d-lg-none" href="{% url 'brainrot:counter' %}?mode=six_seven" aria-label="Play 67 Counter">
+          <span>67</span>
+        </a>
+
+        <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#siteNavbar" aria-controls="siteNavbar" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+        </button>
+
+        <div class="collapse navbar-collapse" id="siteNavbar">
+          <ul class="navbar-nav me-auto align-items-lg-center gap-lg-1">
+            <li class="nav-item d-none d-lg-block">
+              <a class="site-67-shortcut" href="{% url 'brainrot:counter' %}?mode=six_seven">
+                <span>67</span>
+                <small>{% trans "Play" %}</small>
+              </a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="/orac-leaderboards"><i class="fa-solid fa-ranking-star"></i> ORAC LB</a>
+              <a class="nav-link" href="{% url 'brainrot:hall_of_fame' %}"><i class="fa-solid fa-ranking-star me-1"></i> 67 HOF</a>
             </li>
             <li class="nav-item">
-              <a class="nav-link" href="{% url 'brainrot:index' %}"><i class="fa-solid fa-flask"></i> {% translate "61/67 Lab" %}</a>
+              <a class="nav-link" href="{% url 'brainrot:index' %}"><i class="fa-solid fa-gamepad me-1"></i> {% trans "Games" %}</a>
             </li>
-            <li class="nav-item">
-              <a class="nav-link" href="/oj"><i class="fa-solid fa-box-archive"></i> {% trans 'OJ' %}</a>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link" href="#"><i class="fa-solid fa-circle-info"></i> {% trans 'About' %}</a>
+            <li class="nav-item dropdown">
+              <a class="nav-link dropdown-toggle" href="#" id="projectsDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                <i class="fa-solid fa-folder-open me-1"></i> {% trans "Projects" %}
+              </a>
+              <ul class="dropdown-menu site-dropdown" aria-labelledby="projectsDropdown">
+                <li><a class="dropdown-item" href="{% url 'blog' %}"><i class="fa-solid fa-blog me-2"></i>{% trans "Blog" %}</a></li>
+                <li><a class="dropdown-item" href="/orac-leaderboards"><i class="fa-solid fa-ranking-star me-2"></i>ORAC Leaderboards</a></li>
+                <li><a class="dropdown-item" href="/oracdata"><i class="fa-solid fa-chart-line me-2"></i>ORAC Analytics</a></li>
+                <li><hr class="dropdown-divider" /></li>
+                <li><a class="dropdown-item" href="/oj"><i class="fa-solid fa-box-archive me-2"></i>{% trans "OJ" %} <span class="text-secondary">(retired)</span></a></li>
+              </ul>
             </li>
           </ul>
-          <ul class="navbar-nav ms-auto">
-            <!-- Language Dropdown -->
-            <li class="nav-item dropdown me-2">
-              <a class="nav-link dropdown-toggle" href="#" id="languageDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false"><i class="fa-solid fa-language"></i> {% trans 'Language' %}</a>
-              <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="languageDropdown">
+
+          <ul class="navbar-nav ms-auto align-items-lg-center gap-lg-1">
+            <li class="nav-item dropdown">
+              <a class="nav-link dropdown-toggle" href="#" id="languageDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                <i class="fa-solid fa-language me-1"></i> {% if CURRENT_LANGUAGE == 'zh-hans' %}中文{% else %}EN{% endif %}
+              </a>
+              <ul class="dropdown-menu dropdown-menu-end site-dropdown" aria-labelledby="languageDropdown">
                 <li>
                   <form method="post" action="{% url 'set_language' %}">
                     {% csrf_token %}
-                    <input type="hidden" name="next" value="{{ request.path }}" />
+                    <input type="hidden" name="next" value="{{ request.get_full_path }}" />
                     <button type="submit" name="language" value="en" class="dropdown-item">English</button>
                     <button type="submit" name="language" value="zh-hans" class="dropdown-item">中文</button>
                   </form>
@@ -90,31 +81,19 @@
               </ul>
             </li>
 
-            <!-- User/Login Dropdown -->
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                <i class="fa-solid fa-user"></i>
-                {% if request.user.is_authenticated %}
-                  {{ request.user.username }}
-                {% else %}
-                  {% trans 'Account' %}
-                {% endif %}
+                <i class="fa-solid fa-user me-1"></i>
+                {% if request.user.is_authenticated %}{{ request.user.username }}{% else %}{% trans "Account" %}{% endif %}
               </a>
-              <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="userDropdown">
+              <ul class="dropdown-menu dropdown-menu-end site-dropdown" aria-labelledby="userDropdown">
                 {% if request.user.is_authenticated %}
-                  <li>
-                    <a class="dropdown-item" href="{% url 'brainrot:my_hall_of_fame' %}">{% translate "My 67 Hall of Fame" %}</a>
-                  </li>
-                  <li>
-                    <a class="dropdown-item" href="{% url 'logout' %}">{% trans 'Logout' %}</a>
-                  </li>
+                  <li><a class="dropdown-item" href="{% url 'brainrot:my_hall_of_fame' %}"><i class="fa-solid fa-medal me-2"></i>{% translate "My 67 Hall of Fame" %}</a></li>
+                  <li><hr class="dropdown-divider" /></li>
+                  <li><a class="dropdown-item" href="{% url 'logout' %}"><i class="fa-solid fa-right-from-bracket me-2"></i>{% trans "Logout" %}</a></li>
                 {% else %}
-                  <li>
-                    <a class="dropdown-item" href="{% url 'login' %}">{% trans 'Login' %}</a>
-                  </li>
-                  <li>
-                    <a class="dropdown-item" href="{% url 'register' %}">{% trans 'Register' %}</a>
-                  </li>
+                  <li><a class="dropdown-item" href="{% url 'login' %}"><i class="fa-solid fa-right-to-bracket me-2"></i>{% trans "Login" %}</a></li>
+                  <li><a class="dropdown-item" href="{% url 'register' %}"><i class="fa-solid fa-user-plus me-2"></i>{% trans "Register" %}</a></li>
                 {% endif %}
               </ul>
             </li>
@@ -124,24 +103,24 @@
     </nav>
 
     <div class="content">
-      {% block content %}
-
-      {% endblock %}
+      {% block content %}{% endblock %}
     </div>
 
-    <footer class="bg-dark text-white">
-      <style>
-        footer {
-          margin-top: 30px;
-          color: white;
-          padding: 10px 20px;
-          text-align: center;
-        }
-      </style>
-      <div class="container">
-        <p>&copy; 2025 Henry's Website. All rights reserved.</p>
+    <footer class="site-footer">
+      <div class="container-xl d-flex flex-column flex-md-row justify-content-between align-items-center gap-2">
+        <span>&copy; {% now "Y" %} Henry · icaijy.com</span>
+        <span class="site-footer-links">
+          <a href="{% url 'brainrot:counter' %}?mode=six_seven">67</a>
+          <a href="{% url 'brainrot:hall_of_fame' %}">HOF</a>
+          <a href="{% url 'blog' %}">{% trans "Blog" %}</a>
+          <a href="https://github.com/icaijy" rel="me">GitHub</a>
+        </span>
       </div>
     </footer>
+
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/highlight.min.js"></script>
+    <script>document.addEventListener('DOMContentLoaded', () => window.hljs?.highlightAll());</script>
     <script type="text/x-mathjax-config">
       MathJax.Hub.Config({
         config: ['MMLorHTML.js'],
@@ -150,5 +129,6 @@
       })
     </script>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-MML-AM_CHTML"></script>
+    {% block extra_scripts %}{% endblock %}
   </body>
 </html>


### PR DESCRIPTION
## Tonight's cleanup

This is the site-polish follow-up after the Voice 67 model experiments.

### Voice 67: park the prototype cleanly

- `/67/voice/` is now a **Coming Soon** page instead of loading a detector that only works at slow speech.
- The page has direct English/简体中文 copy so the Chinese version is useful immediately without waiting on a gettext catalogue rebuild.
- It records the actual next direction: a tiny purpose-built continuous-speech model rather than another generic ASR/wake-word patch.
- Existing Voice HOF entries remain watchable, but new runs and Voice challenges are paused.
- Voice HOF buttons now say Coming Soon instead of pretending a challenge can start.

### Make 67 impossible to miss

- Reworked the homepage around a large **Play 67 now** hero and giant clickable `67` mark.
- 67 also gets a dedicated neon shortcut in the global navbar on desktop and mobile.
- `/67/` now treats the normal 67 Counter as the full-width main event; Tung Tung, Voice Coming Soon and typing sit below it.
- ORAC/blog/analytics are still easy to find from the navbar and homepage, but they no longer compete with the thing classmates actually visit for.

### Modernise the old global shell

- Rebuilt `base.html` around Bootstrap 5.3 only; removed the old jQuery + Bootstrap-4-JS + Bootstrap-5-JS mixture.
- Added a sticky compact navigation bar, clearer Projects / language / account menus, a real mobile 67 shortcut, and a useful footer.
- Refreshed global typography, cards, buttons, dropdowns and spacing.
- Updated the ORAC leaderboard tabs from `data-toggle` to Bootstrap 5 `data-bs-toggle` so they keep working after the shell cleanup.

### MP4 downloads / iPhone path

The existing HOF detail flow fetched the stored WebM and asked the **viewer's browser** to transcode it with Mediabunny/WebCodecs. That works on the current desktop setup but is a bad dependency for an iPhone download.

New public UI download links use the existing HOF video URL with `?download=1&format=mp4`:

- Django invokes the server's `ffmpeg` only for the explicit MP4 download.
- Output is H.264 + AAC MP4, `yuv420p`, Baseline profile, with `+faststart` for broad phone compatibility.
- The short transcode is written to a temporary file under private media, opened for `FileResponse`, then unlinked immediately on Linux; there is no permanent duplicate MP4 archive.
- Inline HOF playback is unchanged and still streams the original stored evidence.
- Legacy `?download=1` remains compatible for old links/tests; all visible site download buttons now explicitly request MP4.
- HOF list, HOF detail, My HOF and Django admin all use the MP4 route.
- The old HOF-detail client-side WebM→MP4 conversion hook is removed. Local just-finished runs retain the existing frontend MP4 exporter as their browser-local fallback.

### Tests / validation added

- Updated Voice tests for the Coming Soon state and added direct Chinese-copy coverage.
- Added `test_downloads.py` covering legacy download compatibility, MP4 response headers, and visible MP4 links.
- Reviewed the branch diff for old Bootstrap `data-toggle`/jQuery dependencies; the ORAC tab page was the relevant Bootstrap-4 holdover found and was migrated.
- New Python modules were syntax-parsed successfully.

**Not claimed:** the full Django test suite was not run in this environment, and the production `ffmpeg/libx264` path still needs one real server smoke test plus one iPhone download test before merge/deploy confidence is complete.

### Production smoke test before merge

1. Open homepage on desktop + phone and confirm the new navbar collapses correctly.
2. Switch to Chinese and open `/67/voice/`; confirm the Chinese Coming Soon page appears.
3. Check `/67/`, 67 Counter, Tung Tung, ORAC leaderboard tabs and HOF pages.
4. On the server run `ffmpeg -version` and `ffmpeg -encoders | grep libx264`.
5. Download an old WebM HOF entry from the new **Download MP4** button and confirm the filename/MIME are MP4.
6. Repeat #5 on an iPhone/Safari.
7. Run the Django suite before final merge if convenient.
