### PR TITLE
Stop transcoding HOF uploads on the Raspberry Pi

### DIFF
--- a/brainrot/download_views.py
+++ b/brainrot/download_views.py
@@ -6,7 +6,7 @@ from .models import HallOfFameEntry
 
 
 def hall_of_fame_video(request, entry_id):
-    """Stream the stored recording directly; persisted HOF videos are canonical MP4."""
+    """Stream the validated stored recording directly without server transcoding."""
     entry = get_object_or_404(HallOfFameEntry.objects.select_related('user'), pk=entry_id)
     may_view = (
         entry.visibility == HallOfFameEntry.Visibility.PUBLIC

--- a/brainrot/test_mp4_storage.py
+++ b/brainrot/test_mp4_storage.py
@@ -2,18 +2,15 @@ import json
 import tempfile
 from unittest.mock import patch
 
-from django.core.exceptions import ValidationError
-from django.core.files.base import ContentFile
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.test import TestCase, override_settings
 
 from .models import HallOfFameEntry
 from .validators import ValidatedVideo, validate_hall_of_fame_video
-from .video_mp4 import Mp4TranscodeError
 
 
 @override_settings(DEBUG=True, TURNSTILE_ENABLED=False, HOF_SUBMISSIONS_PER_MINUTE=3)
-class HallOfFameCanonicalMp4StorageTests(TestCase):
+class HallOfFameNativeVideoStorageTests(TestCase):
     def setUp(self):
         self.private_directory = tempfile.TemporaryDirectory()
         self.override = override_settings(PRIVATE_MEDIA_ROOT=self.private_directory.name)
@@ -24,34 +21,72 @@ class HallOfFameCanonicalMp4StorageTests(TestCase):
         self.private_directory.cleanup()
 
     @patch('brainrot.validators._probe_video', return_value=23.0)
-    @patch('brainrot.validators.transcode_upload_to_content_file')
-    def test_validator_replaces_browser_upload_with_mp4(self, transcode, probe):
+    def test_validator_keeps_webm_upload_native(self, probe):
+        payload = b'\x1aE\xdf\xa3browser-evidence'
         source = SimpleUploadedFile(
             'browser.webm',
-            b'\x1aE\xdf\xa3browser-evidence',
+            payload,
             content_type='video/webm',
         )
-        transcode.return_value = ContentFile(b'canonical-mp4-bytes', name='recording.mp4')
+
+        inspected = validate_hall_of_fame_video(source)
+
+        self.assertEqual(inspected, ValidatedVideo('video/webm', 'webm', 23.0))
+        self.assertEqual(source.content_type, 'video/webm')
+        self.assertEqual(source.name, 'browser.webm')
+        self.assertEqual(source.read(), payload)
+
+    @patch('brainrot.validators._probe_video', return_value=23.0)
+    def test_validator_keeps_mp4_upload_native(self, probe):
+        payload = b'\x00\x00\x00\x18ftypisom-browser-evidence'
+        source = SimpleUploadedFile(
+            'browser.mp4',
+            payload,
+            content_type='video/mp4',
+        )
 
         inspected = validate_hall_of_fame_video(source)
 
         self.assertEqual(inspected, ValidatedVideo('video/mp4', 'mp4', 23.0))
         self.assertEqual(source.content_type, 'video/mp4')
-        self.assertTrue(source.name.endswith('.mp4'))
-        self.assertEqual(source.read(), b'canonical-mp4-bytes')
+        self.assertEqual(source.name, 'browser.mp4')
+        self.assertEqual(source.read(), payload)
 
-    @patch('brainrot.views.validate_hall_of_fame_video')
-    def test_submission_persists_canonicalised_upload(self, validate):
-        def canonicalise(upload):
-            canonical = ContentFile(b'canonical-mp4-bytes', name='recording.mp4')
-            upload.file = canonical
-            upload.name = canonical.name
-            upload.size = canonical.size
-            upload.content_type = 'video/mp4'
-            return ValidatedVideo('video/mp4', 'mp4', 23.0)
+    @patch('brainrot.video_mp4.transcode_upload_to_content_file')
+    @patch('brainrot.validators._probe_video', return_value=23.0)
+    def test_submission_persists_native_webm_without_server_transcode(self, probe, transcode):
+        payload = b'\x1aE\xdf\xa3browser-evidence'
+        source = SimpleUploadedFile(
+            'browser.webm',
+            payload,
+            content_type='video/webm',
+        )
 
-        validate.side_effect = canonicalise
-        source = SimpleUploadedFile('browser.webm', b'placeholder', content_type='video/webm')
+        response = self.client.post('/67/submit/', {
+            'score': 3,
+            'display_name': 'Native Swan',
+            'event_timeline': json.dumps([1.0, 2.0, 3.0]),
+            'publication_consent': 'yes',
+            'video': source,
+        })
+
+        self.assertEqual(response.status_code, 201)
+        transcode.assert_not_called()
+        entry = HallOfFameEntry.objects.get()
+        self.assertEqual(entry.mime_type, 'video/webm')
+        self.assertTrue(entry.video.name.endswith('.webm'))
+        self.assertEqual(entry.video.read(), payload)
+
+    @patch('brainrot.video_mp4.transcode_upload_to_content_file')
+    @patch('brainrot.validators._probe_video', return_value=23.0)
+    def test_submission_persists_native_mp4_without_server_transcode(self, probe, transcode):
+        payload = b'\x00\x00\x00\x18ftypisom-browser-evidence'
+        source = SimpleUploadedFile(
+            'browser.mp4',
+            payload,
+            content_type='video/mp4',
+        )
+
         response = self.client.post('/67/submit/', {
             'score': 3,
             'display_name': 'MP4 Swan',
@@ -61,20 +96,8 @@ class HallOfFameCanonicalMp4StorageTests(TestCase):
         })
 
         self.assertEqual(response.status_code, 201)
+        transcode.assert_not_called()
         entry = HallOfFameEntry.objects.get()
         self.assertEqual(entry.mime_type, 'video/mp4')
         self.assertTrue(entry.video.name.endswith('.mp4'))
-        self.assertEqual(entry.video.read(), b'canonical-mp4-bytes')
-
-    @patch('brainrot.validators._probe_video', return_value=23.0)
-    @patch('brainrot.validators.transcode_upload_to_content_file')
-    def test_transcode_failure_is_validation_failure(self, transcode, probe):
-        transcode.side_effect = Mp4TranscodeError('ffmpeg failed')
-        source = SimpleUploadedFile(
-            'browser.webm',
-            b'\x1aE\xdf\xa3browser-evidence',
-            content_type='video/webm',
-        )
-        with self.assertRaisesMessage(ValidationError, 'ffmpeg failed'):
-            validate_hall_of_fame_video(source)
-        self.assertEqual(HallOfFameEntry.objects.count(), 0)
+        self.assertEqual(entry.video.read(), payload)

--- a/brainrot/validators.py
+++ b/brainrot/validators.py
@@ -8,8 +8,6 @@ from dataclasses import dataclass
 from django.conf import settings
 from django.core.exceptions import ValidationError
 
-from .video_mp4 import Mp4TranscodeError, transcode_upload_to_content_file
-
 
 @dataclass(frozen=True)
 class ValidatedVideo:
@@ -128,12 +126,12 @@ def _probe_video(upload, expected_mime):
 
 
 def validate_hall_of_fame_video(upload):
-    """Validate a browser upload and replace it with a canonical MP4 payload."""
+    """Validate a browser recording without transcoding it on the web server."""
     if upload.size <= 0 or upload.size > settings.HOF_MAX_UPLOAD_BYTES:
         max_mb = settings.HOF_MAX_UPLOAD_BYTES / (1024 * 1024)
         raise ValidationError(f'Video must be no larger than {max_mb:g} MB.')
 
-    mime_type, _extension = _sniff_container(upload)
+    mime_type, extension = _sniff_container(upload)
     supplied_type = (upload.content_type or '').split(';', 1)[0].lower()
     compatible_types = {
         'video/webm': {'video/webm', 'application/octet-stream'},
@@ -144,16 +142,4 @@ def validate_hall_of_fame_video(upload):
 
     duration = _probe_video(upload, mime_type)
     upload.seek(0)
-    try:
-        canonical = transcode_upload_to_content_file(upload)
-    except Mp4TranscodeError as exc:
-        raise ValidationError(str(exc)) from exc
-
-    # Preserve the UploadedFile object expected by the existing submission view,
-    # but make its contents and metadata canonical MP4 before FileField.save().
-    upload.file = canonical
-    upload.name = canonical.name
-    upload.size = canonical.size
-    upload.content_type = 'video/mp4'
-    upload.seek(0)
-    return ValidatedVideo('video/mp4', 'mp4', duration)
+    return ValidatedVideo(mime_type, extension, duration)


### PR DESCRIPTION
## What changed
- HOF upload validation now only verifies the genuine container, codec, size, and duration.
- Accepted WebM/MP4 recordings are stored in their native browser format instead of being synchronously transcoded with ffmpeg inside the upload request.
- The stored MIME type and extension come from server-side container sniffing, so FileField storage remains accurate.
- Direct video streaming continues to serve the validated stored file as-is.
- Tests now cover native WebM and MP4 submissions and explicitly assert that the server-side transcoder is never called during upload.

## Root cause
The production upload path called `transcode_upload_to_content_file()` for every accepted recording, including recordings that were already MP4. That runs H.264 encoding synchronously on the Raspberry Pi request worker. The Pi has already demonstrated that these encodes can exceed the 45-second timeout, so phone submissions can fail even when the recording itself is valid.

## Result
The Raspberry Pi still uses lightweight `ffprobe` inspection for validation, but it never performs video transcoding during a user upload. Existing historical MP4s are untouched. Browsers that record WebM may store WebM; the existing browser-side Download MP4 flow can still convert downloads on the user's device.

## Validation
Code-level regression tests were updated for native WebM and MP4 persistence and no-transcode behavior. The connector environment cannot execute the Django suite, so run `python manage.py test brainrot.test_mp4_storage brainrot.test_downloads` before merging.