### PR TITLE
Expose 67 social surfaces and admin cosmetics

### DIFF
--- a/brainrot/economy_views.py
+++ b/brainrot/economy_views.py
@@ -1,7 +1,7 @@
 from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.db.models import Prefetch
-from django.http import HttpResponse
+from django.http import HttpResponse, JsonResponse
 from django.shortcuts import get_object_or_404, redirect, render
 from django.utils import timezone
 from django.views.decorators.http import require_POST
@@ -19,7 +19,7 @@ from .economy import (
     unequip_cosmetic,
     wealth_rows,
 )
-from .models import Cosmetic, CosmeticOffer, CurrencyTransaction, EquippedCosmetic, HallOfFameEntry
+from .models import Cosmetic, CosmeticOffer, CurrencyTransaction, EquippedCosmetic, HallOfFameComment, HallOfFameEntry, UserCosmetic
 
 
 def _settle():
@@ -62,6 +62,40 @@ def wealth(request):
     })
 
 
+def daily_preview(request):
+    """Tiny main-67 Today leaderboard used by the global /67 widget."""
+    _settle()
+    entries = leaderboard(
+        period='today',
+        game_mode=HallOfFameEntry.GameMode.SIX_SEVEN,
+        limit=5,
+    )
+    return JsonResponse({
+        'entries': [
+            {
+                'rank': index,
+                'name': entry.user.username,
+                'score': entry.score,
+                'private': entry.visibility == HallOfFameEntry.Visibility.PRIVATE,
+            }
+            for index, entry in enumerate(entries, start=1)
+        ],
+        'date': timezone.localdate().isoformat(),
+    })
+
+
+def latest_comments(request):
+    """Newest comments across every public HOF specimen."""
+    _settle()
+    comments = list(
+        HallOfFameComment.objects.filter(entry__visibility=HallOfFameEntry.Visibility.PUBLIC)
+        .select_related('user', 'entry', 'entry__user')
+        .order_by('-created_at', '-id')[:100]
+    )
+    decorate_user_objects(comments)
+    return render(request, 'brainrot/latest_comments.html', {'comments': comments})
+
+
 def cosmetics_css(request):
     response = HttpResponse(cosmetic_stylesheet(), content_type='text/css; charset=utf-8')
     response['Cache-Control'] = 'public, max-age=30'
@@ -77,9 +111,9 @@ def _shop_cosmetics(user):
     now = timezone.now()
     for cosmetic in cosmetics:
         cosmetic.ownership = owned_rows.get(cosmetic.pk)
-        cosmetic.is_active_owned = cosmetic.pk in active_ids
-        cosmetic.is_equipped = cosmetic.is_active_owned and equipped.get(cosmetic.category) == cosmetic.pk
-        cosmetic.is_permanent = bool(cosmetic.ownership and cosmetic.ownership.expires_at is None)
+        cosmetic.is_active_owned = user.is_superuser or cosmetic.pk in active_ids
+        cosmetic.is_equipped = equipped.get(cosmetic.category) == cosmetic.pk
+        cosmetic.is_permanent = user.is_superuser or bool(cosmetic.ownership and cosmetic.ownership.expires_at is None)
         cosmetic.is_expired = bool(cosmetic.ownership and cosmetic.ownership.expires_at and cosmetic.ownership.expires_at <= now)
         cosmetic.active_offers = list(cosmetic.offers.all())
     return cosmetics
@@ -141,6 +175,14 @@ def equip(request, cosmetic_id):
     # Disabled cosmetics remain equippable for existing owners.
     cosmetic = get_object_or_404(Cosmetic, pk=cosmetic_id)
     try:
+        if request.user.is_superuser:
+            # Admin privilege: selecting a skin is free and permanent. No wallet
+            # transaction is posted; the ownership row only makes rendering and
+            # inventory use the same normal path as everyone else.
+            owned, _ = UserCosmetic.objects.get_or_create(user=request.user, cosmetic=cosmetic)
+            if owned.expires_at is not None:
+                owned.expires_at = None
+                owned.save(update_fields=['expires_at'])
         equip_cosmetic(request.user, cosmetic)
         messages.success(request, f'Equipped {cosmetic.name}.')
     except ValueError as exc:

--- a/brainrot/static/brainrot/daily_widget.js
+++ b/brainrot/static/brainrot/daily_widget.js
@@ -1,0 +1,34 @@
+const widget = document.getElementById('daily-mini-widget');
+if (widget) {
+  const list = widget.querySelector('[data-daily-mini-list]');
+  const status = widget.querySelector('[data-daily-mini-status]');
+  fetch(widget.dataset.endpoint, { credentials: 'same-origin' })
+    .then((response) => {
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      return response.json();
+    })
+    .then((payload) => {
+      status?.remove();
+      const entries = payload.entries || [];
+      if (!entries.length) {
+        list.innerHTML = '<div class="small text-secondary">Nobody has wasted 20 seconds yet today.</div>';
+        return;
+      }
+      list.innerHTML = entries.map((entry) => `
+        <div class="daily-mini-row">
+          <span class="daily-mini-rank">#${entry.rank}</span>
+          <span class="daily-mini-name">${escapeHtml(entry.name)}</span>
+          <strong>${entry.score}${entry.private ? '<span class="daily-mini-lock" title="Private run"> 🔒</span>' : ''}</strong>
+        </div>
+      `).join('');
+    })
+    .catch(() => {
+      if (status) status.textContent = 'Today board unavailable';
+    });
+}
+
+function escapeHtml(value) {
+  return String(value).replace(/[&<>'"]/g, (character) => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', "'": '&#39;', '"': '&quot;',
+  })[character]);
+}

--- a/brainrot/templates/brainrot/latest_comments.html
+++ b/brainrot/templates/brainrot/latest_comments.html
@@ -1,0 +1,43 @@
+{% extends 'base.html' %}
+{% load i18n %}
+{% block title %}Latest 67 Comments{% endblock %}
+{% block content %}
+<link rel="stylesheet" href="{% url 'brainrot:cosmetics_css' %}">
+<main class="container py-4 py-md-5">
+  <div class="d-flex flex-wrap justify-content-between align-items-end gap-3 mb-4">
+    <div>
+      <div class="text-secondary small text-uppercase fw-semibold">LIVE PEER REVIEW FEED</div>
+      <h1 class="display-5 fw-bold mb-1">Latest comments</h1>
+      <p class="lead text-secondary mb-0">Who is saying what under which extremely important HOF specimen.</p>
+    </div>
+    <a class="btn btn-outline-dark" href="{% url 'brainrot:hall_of_fame' %}">Hall of Fame →</a>
+  </div>
+
+  <div class="d-grid gap-3">
+    {% for comment in comments %}
+      <article class="card shadow-sm {% if comment.comment_cosmetic %}cosmetic-{{ comment.comment_cosmetic.id }}{% endif %}" id="comment-{{ comment.id }}">
+        <div class="card-body p-3 p-md-4">
+          <div class="d-flex flex-wrap align-items-center gap-2 mb-2">
+            <strong class="{% if comment.username_cosmetic %}cosmetic-{{ comment.username_cosmetic.id }}{% endif %}">{{ comment.public_name }}</strong>
+            {% if comment.badge_cosmetic %}<span class="badge cosmetic-{{ comment.badge_cosmetic.id }}">{{ comment.badge_cosmetic.badge_text|default:comment.badge_cosmetic.name }}</span>{% endif %}
+            {% if comment.is_original_poster %}<span class="badge text-bg-primary">OP</span>{% endif %}
+            {% if comment.is_submission_note %}<span class="badge text-bg-light border text-dark">submission note</span>{% endif %}
+            <span class="small text-secondary ms-sm-auto">{{ comment.created_at|date:'j M Y · H:i' }}</span>
+          </div>
+          <div class="mb-3">{{ comment.rendered_body }}</div>
+          <div class="small text-secondary d-flex flex-wrap gap-2 align-items-center">
+            <span>{{ comment.entry.get_game_mode_display }}</span>
+            <span>·</span>
+            <strong>{{ comment.entry.score }}</strong>
+            <span>·</span>
+            <span>{{ comment.entry.public_name }}</span>
+            <a class="ms-sm-auto" href="{% url 'brainrot:hall_of_fame_detail' comment.entry_id %}?comment_sort=newest#comment-{{ comment.id }}">Open thread →</a>
+          </div>
+        </div>
+      </article>
+    {% empty %}
+      <div class="alert alert-light border">No public comments yet. Civilization remains silent.</div>
+    {% endfor %}
+  </div>
+</main>
+{% endblock %}

--- a/brainrot/test_social_surfaces.py
+++ b/brainrot/test_social_surfaces.py
@@ -1,0 +1,52 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+
+from .models import Cosmetic, HallOfFameComment, HallOfFameEntry, UserCosmetic
+
+
+class SocialSurfaceTests(TestCase):
+    def entry(self, user, score, visibility='public'):
+        return HallOfFameEntry.objects.create(
+            user=user,
+            game_mode='six_seven',
+            score=score,
+            video='hall_of_fame/test.mp4',
+            mime_type='video/mp4',
+            duration_seconds=20,
+            event_timeline=[],
+            visibility=visibility,
+        )
+
+    def test_admin_can_equip_any_cosmetic_for_free(self):
+        User = get_user_model()
+        admin = User.objects.create_superuser(username='centralbank', email='admin@example.com', password='x')
+        cosmetic = Cosmetic.objects.create(name='Admin Aura', slug='admin-aura', category='username')
+        self.client.force_login(admin)
+        response = self.client.post(f'/67/shop/equip/{cosmetic.pk}/', {'next': '/67/shop/'})
+        self.assertEqual(response.status_code, 302)
+        owned = UserCosmetic.objects.get(user=admin, cosmetic=cosmetic)
+        self.assertIsNone(owned.expires_at)
+        self.assertEqual(admin.equipped_cosmetics.get(category='username').cosmetic_id, cosmetic.pk)
+
+    def test_latest_comments_hides_private_threads(self):
+        User = get_user_model()
+        alice = User.objects.create_user(username='alice67', password='x')
+        bob = User.objects.create_user(username='bob67', password='x')
+        public_entry = self.entry(alice, 150, 'public')
+        private_entry = self.entry(bob, 160, 'private')
+        HallOfFameComment.objects.create(entry=public_entry, user=alice, author_name='alice67', body='public hello')
+        HallOfFameComment.objects.create(entry=private_entry, user=bob, author_name='bob67', body='private hello')
+        response = self.client.get('/67/comments/')
+        self.assertContains(response, 'public hello')
+        self.assertNotContains(response, 'private hello')
+
+    def test_daily_mini_returns_best_today(self):
+        User = get_user_model()
+        alice = User.objects.create_user(username='alice67', password='x')
+        bob = User.objects.create_user(username='bob67', password='x')
+        self.entry(alice, 150, 'private')
+        self.entry(bob, 140, 'public')
+        response = self.client.get('/67/daily-mini/')
+        self.assertEqual(response.status_code, 200)
+        first = response.json()['entries'][0]
+        self.assertEqual((first['name'], first['score'], first['private']), ('alice67', 150, True))

--- a/brainrot/urls.py
+++ b/brainrot/urls.py
@@ -15,6 +15,8 @@ urlpatterns = [
     path('submit/', views.submit_hall_of_fame, name='submit_hall_of_fame'),
 
     path('daily/', economy_views.daily, name='daily'),
+    path('daily-mini/', economy_views.daily_preview, name='daily_preview'),
+    path('comments/', economy_views.latest_comments, name='latest_comments'),
     path('wealth/', economy_views.wealth, name='wealth'),
     path('shop/', economy_views.shop, name='shop'),
     path('inventory/', economy_views.inventory, name='inventory'),

--- a/templates/base.html
+++ b/templates/base.html
@@ -14,6 +14,12 @@
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/styles/default.min.css" />
     <link rel="stylesheet" type="text/css" href="{% static 'global.css' %}" />
     <link rel="stylesheet" type="text/css" href="{% static 'monokai.css' %}" />
+    <style>
+      .daily-mini-widget{position:fixed;right:1rem;bottom:1rem;width:min(280px,calc(100vw - 2rem));z-index:1020;background:rgba(255,255,255,.96);backdrop-filter:blur(10px);border:1px solid rgba(15,23,42,.16);border-radius:14px;box-shadow:0 18px 45px rgba(15,23,42,.18);overflow:hidden}
+      .daily-mini-head{display:flex;align-items:center;justify-content:space-between;gap:.5rem;padding:.7rem .85rem;background:#0f172a;color:#fff;text-decoration:none}
+      .daily-mini-head:hover{color:#d8ff62}.daily-mini-list{padding:.55rem .75rem .7rem}.daily-mini-row{display:grid;grid-template-columns:2rem minmax(0,1fr) auto;align-items:center;gap:.35rem;padding:.23rem 0;font-size:.84rem}.daily-mini-rank{color:#64748b;font-variant-numeric:tabular-nums}.daily-mini-name{overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.daily-mini-lock{font-size:.68rem}
+      @media (max-width: 767.98px){.daily-mini-widget{right:.65rem;bottom:.65rem;width:230px}.daily-mini-list{max-height:150px;overflow:auto}}
+    </style>
     {% block extra_head %}{% endblock %}
   </head>
 
@@ -28,9 +34,7 @@
           </span>
         </a>
 
-        <a class="site-67-shortcut d-lg-none" href="{% url 'brainrot:counter' %}?mode=six_seven" aria-label="Play 67 Counter">
-          <span>67</span>
-        </a>
+        <a class="site-67-shortcut d-lg-none" href="{% url 'brainrot:counter' %}?mode=six_seven" aria-label="Play 67 Counter"><span>67</span></a>
 
         <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#siteNavbar" aria-controls="siteNavbar" aria-expanded="false" aria-label="Toggle navigation">
           <span class="navbar-toggler-icon"></span>
@@ -39,21 +43,16 @@
         <div class="collapse navbar-collapse" id="siteNavbar">
           <ul class="navbar-nav me-auto align-items-lg-center gap-lg-1">
             <li class="nav-item d-none d-lg-block">
-              <a class="site-67-shortcut" href="{% url 'brainrot:counter' %}?mode=six_seven">
-                <span>67</span>
-                <small>{% trans "Play" %}</small>
-              </a>
+              <a class="site-67-shortcut" href="{% url 'brainrot:counter' %}?mode=six_seven"><span>67</span><small>{% trans "Play" %}</small></a>
             </li>
-            <li class="nav-item">
-              <a class="nav-link" href="{% url 'brainrot:hall_of_fame' %}"><i class="fa-solid fa-ranking-star me-1"></i> 67 HOF</a>
-            </li>
-            <li class="nav-item">
-              <a class="nav-link" href="{% url 'brainrot:index' %}"><i class="fa-solid fa-gamepad me-1"></i> {% trans "Games" %}</a>
-            </li>
+            <li class="nav-item"><a class="nav-link" href="{% url 'brainrot:hall_of_fame' %}"><i class="fa-solid fa-ranking-star me-1"></i> HOF</a></li>
+            <li class="nav-item"><a class="nav-link" href="{% url 'brainrot:daily' %}"><i class="fa-solid fa-calendar-day me-1"></i> Daily</a></li>
+            <li class="nav-item"><a class="nav-link" href="{% url 'brainrot:latest_comments' %}"><i class="fa-regular fa-comments me-1"></i> Comments</a></li>
+            <li class="nav-item"><a class="nav-link" href="{% url 'brainrot:shop' %}"><i class="fa-solid fa-bag-shopping me-1"></i> Shop</a></li>
+            <li class="nav-item"><a class="nav-link" href="{% url 'brainrot:wealth' %}"><i class="fa-solid fa-sack-dollar me-1"></i> Rich</a></li>
+            <li class="nav-item"><a class="nav-link" href="{% url 'brainrot:index' %}"><i class="fa-solid fa-gamepad me-1"></i> {% trans "Games" %}</a></li>
             <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle" href="#" id="projectsDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                <i class="fa-solid fa-folder-open me-1"></i> {% trans "Projects" %}
-              </a>
+              <a class="nav-link dropdown-toggle" href="#" id="projectsDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false"><i class="fa-solid fa-folder-open me-1"></i> {% trans "Projects" %}</a>
               <ul class="dropdown-menu site-dropdown" aria-labelledby="projectsDropdown">
                 <li><a class="dropdown-item" href="{% url 'blog' %}"><i class="fa-solid fa-blog me-2"></i>{% trans "Blog" %}</a></li>
                 <li><a class="dropdown-item" href="/orac-leaderboards"><i class="fa-solid fa-ranking-star me-2"></i>ORAC Leaderboards</a></li>
@@ -66,9 +65,7 @@
 
           <ul class="navbar-nav ms-auto align-items-lg-center gap-lg-1">
             <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle" href="#" id="languageDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                <i class="fa-solid fa-language me-1"></i> {% if CURRENT_LANGUAGE == 'zh-hans' %}中文{% else %}EN{% endif %}
-              </a>
+              <a class="nav-link dropdown-toggle" href="#" id="languageDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false"><i class="fa-solid fa-language me-1"></i> {% if CURRENT_LANGUAGE == 'zh-hans' %}中文{% else %}EN{% endif %}</a>
               <ul class="dropdown-menu dropdown-menu-end site-dropdown" aria-labelledby="languageDropdown">
                 <li>
                   <form method="post" action="{% url 'set_language' %}">
@@ -83,11 +80,11 @@
 
             <li class="nav-item dropdown">
               <a class="nav-link dropdown-toggle" href="#" id="userDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
-                <i class="fa-solid fa-user me-1"></i>
-                {% if request.user.is_authenticated %}{{ request.user.username }}{% else %}{% trans "Account" %}{% endif %}
+                <i class="fa-solid fa-user me-1"></i>{% if request.user.is_authenticated %}{{ request.user.username }}{% else %}{% trans "Account" %}{% endif %}
               </a>
               <ul class="dropdown-menu dropdown-menu-end site-dropdown" aria-labelledby="userDropdown">
                 {% if request.user.is_authenticated %}
+                  <li><a class="dropdown-item" href="{% url 'brainrot:inventory' %}"><i class="fa-solid fa-wand-magic-sparkles me-2"></i>My Cosmetics</a></li>
                   <li><a class="dropdown-item" href="{% url 'brainrot:my_hall_of_fame' %}"><i class="fa-solid fa-medal me-2"></i>{% translate "My 67 Hall of Fame" %}</a></li>
                   <li><hr class="dropdown-divider" /></li>
                   <li><a class="dropdown-item" href="{% url 'logout' %}"><i class="fa-solid fa-right-from-bracket me-2"></i>{% trans "Logout" %}</a></li>
@@ -102,9 +99,16 @@
       </div>
     </nav>
 
-    <div class="content">
-      {% block content %}{% endblock %}
-    </div>
+    <div class="content">{% block content %}{% endblock %}</div>
+
+    {% if request.resolver_match.namespace == 'brainrot' and request.resolver_match.url_name != 'daily' %}
+      <aside class="daily-mini-widget" id="daily-mini-widget" data-endpoint="{% url 'brainrot:daily_preview' %}">
+        <a class="daily-mini-head" href="{% url 'brainrot:daily' %}"><strong><i class="fa-solid fa-bolt me-1"></i> Today's 67</strong><span class="small">full board →</span></a>
+        <div class="daily-mini-list" data-daily-mini-list>
+          <div class="small text-secondary" data-daily-mini-status>Loading today's scientific standings…</div>
+        </div>
+      </aside>
+    {% endif %}
 
     <footer class="site-footer">
       <div class="container-xl d-flex flex-column flex-md-row justify-content-between align-items-center gap-2">
@@ -121,12 +125,9 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js" integrity="sha384-YvpcrYf0tY3lHB60NNkmXc5s9fDVZLESaAA55NDzOxhy9GkcIdslK1eN7N6jIeHz" crossorigin="anonymous"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/11.6.0/highlight.min.js"></script>
     <script>document.addEventListener('DOMContentLoaded', () => window.hljs?.highlightAll());</script>
+    {% if request.resolver_match.namespace == 'brainrot' and request.resolver_match.url_name != 'daily' %}<script type="module" src="{% static 'brainrot/daily_widget.js' %}"></script>{% endif %}
     <script type="text/x-mathjax-config">
-      MathJax.Hub.Config({
-        config: ['MMLorHTML.js'],
-        jax: ['input/TeX', 'output/HTML-CSS', 'output/NativeMML'],
-        extensions: ['MathMenu.js', 'MathZoom.js']
-      })
+      MathJax.Hub.Config({config: ['MMLorHTML.js'],jax: ['input/TeX', 'output/HTML-CSS', 'output/NativeMML'],extensions: ['MathMenu.js', 'MathZoom.js']})
     </script>
     <script type="text/javascript" src="https://cdn.jsdelivr.net/npm/mathjax@2/MathJax.js?config=TeX-MML-AM_CHTML"></script>
     {% block extra_scripts %}{% endblock %}


### PR DESCRIPTION
## Summary

- Let superusers equip any configured cosmetic for free from the shop. The selected skin is granted as permanent ownership without posting a wallet transaction, so normal rendering/inventory logic still applies.
- Promote the 67 ecosystem into the global navbar with direct HOF, Daily, Comments, Shop and Rich List links, plus My Cosmetics in the account menu.
- Add `/67/comments/`, a newest-first feed of comments across every **public** HOF thread. Private HOF comments are excluded.
- Add a global compact **Today's 67** Top 5 widget across `/67` pages (except the full Daily page), backed by a lightweight JSON endpoint. Private daily-eligible runs are marked with a lock icon while still exposing only the same score/rank already shown on the Daily leaderboard.

## Validation

- Python `py_compile`: PASS for changed Python files
- JavaScript `node --check`: PASS for the new Daily widget
- Added tests covering admin free equip, private-comment exclusion, and Daily mini ranking
- No migration or counter/pose logic changes in this follow-up