### PR TITLE
Fix manual HOF video uploads in admin

### DIFF
--- a/brainrot/admin.py
+++ b/brainrot/admin.py
@@ -1,4 +1,6 @@
+from django import forms
 from django.contrib import admin
+from django.core.files.uploadedfile import UploadedFile
 from django.utils.html import format_html
 from django.utils.safestring import mark_safe
 
@@ -14,16 +16,57 @@ from .models import (
     HallOfFameReaction,
     UserCosmetic,
 )
+from .validators import validate_hall_of_fame_video
+
+
+class HallOfFameEntryAdminForm(forms.ModelForm):
+    """Admin upload path for manually restored / legacy HOF recordings.
+
+    Browser submissions populate MIME type, duration and timeline before saving.
+    A manual admin upload does not have that client-side metadata, so inspect the
+    uploaded file here and intentionally allow an empty event timeline.
+    """
+
+    class Meta:
+        model = HallOfFameEntry
+        fields = '__all__'
+        exclude = (
+            'mime_type', 'duration_seconds', 'event_timeline', 'metrics',
+            'asset_value_67', 'asset_revision',
+        )
+
+    def clean_video(self):
+        upload = self.cleaned_data.get('video')
+        if isinstance(upload, UploadedFile):
+            validated = validate_hall_of_fame_video(upload)
+            self._validated_video = validated
+            # upload_to() reads this from the model instance when Django writes
+            # the file, so a WebM uploaded through admin does not get an .mp4 name.
+            self.instance._validated_extension = validated.extension
+        return upload
+
+    def save(self, commit=True):
+        entry = super().save(commit=False)
+        validated = getattr(self, '_validated_video', None)
+        if validated is not None:
+            entry.mime_type = validated.mime_type
+            entry.duration_seconds = validated.duration_seconds
+            entry._validated_extension = validated.extension
+        if commit:
+            entry.save()
+            self.save_m2m()
+        return entry
 
 
 @admin.register(HallOfFameEntry)
 class HallOfFameEntryAdmin(admin.ModelAdmin):
+    form = HallOfFameEntryAdminForm
     list_display = ('submitter', 'game_mode', 'score', 'visibility', 'asset_value_67', 'duration_seconds', 'created_at', 'review_video')
     list_filter = ('game_mode', 'visibility', 'created_at')
     search_fields = ('user__username', 'display_name')
     list_editable = ('score', 'visibility')
     readonly_fields = (
-        'user', 'mime_type', 'duration_seconds', 'event_timeline', 'metrics',
+        'mime_type', 'duration_seconds', 'event_timeline', 'metrics',
         'asset_value_67', 'asset_revision', 'created_at', 'review_video',
     )
     actions = ('make_public', 'make_private')

--- a/brainrot/test_admin_upload.py
+++ b/brainrot/test_admin_upload.py
@@ -1,0 +1,69 @@
+import tempfile
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import TestCase, override_settings
+
+from .admin import HallOfFameEntryAdminForm
+from .models import HallOfFameEntry
+from .validators import ValidatedVideo
+
+
+class ManualHallOfFameAdminUploadTests(TestCase):
+    def setUp(self):
+        User = get_user_model()
+        self.user = User.objects.create_user(username='manual67', password='x')
+
+    def test_admin_upload_populates_video_metadata_and_allows_empty_timeline(self):
+        with tempfile.TemporaryDirectory() as media_root, override_settings(PRIVATE_MEDIA_ROOT=media_root):
+            upload = SimpleUploadedFile(
+                'restored.webm',
+                b'fake-video-for-mocked-validator',
+                content_type='video/webm',
+            )
+            with patch(
+                'brainrot.admin.validate_hall_of_fame_video',
+                return_value=ValidatedVideo('video/webm', 'webm', 20.25),
+            ):
+                form = HallOfFameEntryAdminForm(
+                    data={
+                        'user': self.user.pk,
+                        'display_name': '',
+                        'game_mode': HallOfFameEntry.GameMode.SIX_SEVEN,
+                        'score': 167,
+                        'visibility': HallOfFameEntry.Visibility.PUBLIC,
+                    },
+                    files={'video': upload},
+                )
+                self.assertTrue(form.is_valid(), form.errors.as_json())
+                entry = form.save()
+
+            entry.refresh_from_db()
+            self.assertEqual(entry.user, self.user)
+            self.assertEqual(entry.mime_type, 'video/webm')
+            self.assertAlmostEqual(entry.duration_seconds, 20.25)
+            self.assertEqual(entry.event_timeline, [])
+            self.assertEqual(entry.metrics, {})
+            self.assertTrue(entry.video.name.endswith('.webm'))
+
+    def test_admin_video_validation_error_stays_on_form_instead_of_500(self):
+        upload = SimpleUploadedFile('broken.mp4', b'nope', content_type='video/mp4')
+        from django.core.exceptions import ValidationError
+
+        with patch(
+            'brainrot.admin.validate_hall_of_fame_video',
+            side_effect=ValidationError('The uploaded file is not a readable video.'),
+        ):
+            form = HallOfFameEntryAdminForm(
+                data={
+                    'user': self.user.pk,
+                    'display_name': '',
+                    'game_mode': HallOfFameEntry.GameMode.SIX_SEVEN,
+                    'score': 100,
+                    'visibility': HallOfFameEntry.Visibility.PRIVATE,
+                },
+                files={'video': upload},
+            )
+            self.assertFalse(form.is_valid())
+            self.assertIn('not a readable video', str(form.errors['video']))


### PR DESCRIPTION
## Summary

- Fix Django Admin manual HOF uploads that could hit a server 500 because `mime_type` and `duration_seconds` were required model fields but readonly in Admin and never populated.
- Reuse the existing video validator for Admin uploads so MP4/WebM MIME type, duration and real file extension are detected automatically.
- Allow Admin-created/restored HOF entries to have an empty `event_timeline`; the existing detail page then treats them as legacy runs without exact pacing data while still showing the video and score normally.
- Make the HOF owner (`user`) selectable in Admin so manually restored recordings can be attached to the correct registered account.
- Turn invalid video/ffprobe failures into normal form validation errors instead of database/server errors.

## Validation

- Python `py_compile`: PASS
- Added tests for successful manual WebM metadata population + empty timeline
- Added regression test that video validation failures remain form errors rather than 500s

No migration and no static-file changes are required.